### PR TITLE
Ignore hash comments inside code blocks

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -12,6 +12,8 @@ function addAnchor(header) {
 
 
 function getHashedHeaders (_lines) {
+  var inCodeBlock = false;
+  
   // Turn all headers into '## xxx' even if they were '## xxx ##'
   function normalize(header) {
     return header.replace(/[ #]+$/, '');
@@ -19,6 +21,12 @@ function getHashedHeaders (_lines) {
 
   // Find headers of the form '### xxxx xxx xx [###]'
   return _lines
+    .filter(function (x) {
+      if (x.match(/^```/)) {
+        inCodeBlock = !inCodeBlock;
+      }
+      return !inCodeBlock;
+    })
     .map(function (x, index) {
       var match = /^(\#{1,8})[ ]*(.+)$/.exec(x);
       


### PR DESCRIPTION
Quick-fix for hash-based comments inside ``` code blocks getting processed as headers.
