### PR TITLE
Handle repeated headings.

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -6,14 +6,14 @@ var _      =  require('underscore')
 function notNull(x) { return  x !== null; }
 
 function addAnchor(mode, header) {
-  header.anchor = anchor(header.name, mode);
+  header.anchor = anchor(header.name, mode, header.instance);
   return header;
 }
 
 
 function getHashedHeaders (_lines) {
   var inCodeBlock = false;
-  
+
   // Turn all headers into '## xxx' even if they were '## xxx ##'
   function normalize(header) {
     return header.replace(/[ #]+$/, '');
@@ -29,12 +29,12 @@ function getHashedHeaders (_lines) {
     })
     .map(function (x, index) {
       var match = /^(\#{1,8})[ ]*(.+)$/.exec(x);
-      
+
       return match 
         ? { rank :  match[1].length
           , name :  normalize(match[2])
           , line :  index
-          } 
+          }
         : null;
     })
     .filter(notNull)
@@ -45,12 +45,12 @@ function getUnderlinedHeaders (_lines) {
     // Find headers of the form
     // h1       h2
     // ==       --
-    
+
     return _lines
       .map(function (line, index, lines) {
         if (index === 0) return null;
         var rank;
-            
+
         if (/^==+/.exec(line))      rank = 1;
         else if (/^--+/.exec(line)) rank = 2;
         else                        return null;
@@ -65,19 +65,38 @@ function getUnderlinedHeaders (_lines) {
       .value();
 }
 
+function countHeaders (headers) {
+  var instances = {};
+
+  for (var i = 0; i < headers.length; i++) {
+    var header = headers[i];
+    var name = header.name;
+
+    if (typeof instances[name] === 'number') {
+      instances[name]++;
+    } else {
+      instances[name] = 0;
+    }
+
+    header.instance = instances[name];
+  }
+
+  return headers;
+}
+
 module.exports = function transform(content, mode) {
   var lines         =  content.split('\n')
     , _lines        =  _(lines).chain()
 
-    , allHeaders    =  getHashedHeaders(_lines).concat(getUnderlinedHeaders(_lines))
+    , allHeaders    =  countHeaders(getHashedHeaders(_lines).concat(getUnderlinedHeaders(_lines)))
     , lowestRank    =  _(allHeaders).chain().pluck('rank').min().value()
     , linkedHeaders =  _(allHeaders).map(addAnchor.bind(null, mode));
 
   if (linkedHeaders.length === 0) return { transformed: false };
 
-  var toc = 
-      '**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*'  
-    + '\n\n'                                      
+  var toc =
+      '**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*'
+    + '\n\n'
     + linkedHeaders
         .map(function (x) {
           var indent = _(_.range(x.rank - lowestRank))
@@ -85,14 +104,14 @@ module.exports = function transform(content, mode) {
 
           return indent + '- ' + x.anchor;
         })
-        .join('\n')                                     
+        .join('\n')
     + '\n';
 
   var currentToc = _lines
     .first(linkedHeaders[0].line)
     .value()
     .join('\n');
-    
+
   if (currentToc === toc) return { transformed: false };
 
   // Skip all lines up to first header since that is the old table of content

--- a/test/lib/transform.js
+++ b/test/lib/transform.js
@@ -73,6 +73,17 @@ check(
     ].join('')
 )
 
+check(
+    [ '# Repeating A Title'
+    , ''
+    , '# Repeating A Title'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*\n\n'
+    , '- [Repeating A Title](#repeating-a-title)\n'
+    , '- [Repeating A Title](#repeating-a-title-1)\n\n'
+    ].join('')
+)
+
 // bigbucket.org
 check(
     [ '# My Module'


### PR DESCRIPTION
This relies on https://github.com/thlorenz/anchor-markdown-header/pull/1 to work. When the same text occurs in multiple headings, these now correctly link.
