### PR TITLE
Handle Windows carriage returns.

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -28,7 +28,7 @@ function getHashedHeaders (_lines) {
       return !inCodeBlock;
     })
     .map(function (x, index) {
-      var match = /^(\#{1,8})[ ]*(.+)$/.exec(x);
+      var match = /^(\#{1,8})[ ]*(.+)\r?$/.exec(x);
 
       return match 
         ? { rank :  match[1].length


### PR DESCRIPTION
Currently the regex in `transform` does not work for some files created in Windows, in which a newline is represented by `\r\n`. 

You can also choose to split by `/\r?\n/g` on line 88. Not splitting by `\r\n` is not a problem for the TOC though, since `\r` doesn't render.
