### PR TITLE
Added --stdout flag to output single file transforms to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ If you want to convert only a specific file, do:
 
     doctoc /path/to/file
 
+To output result to stdout, instead of a file, do:
+
+    doctoc --stdout /path/to/file
+
 #### Example
 
     doctoc README.md

--- a/lib/file.js
+++ b/lib/file.js
@@ -32,9 +32,9 @@ function findRec(currentPath) {
     var tgts = _(res.directories).pluck('path');
 
     if (res.markdownFiles.length > 0) 
-      console.log('\nFound %s in "%s"', _(res.markdownFiles).pluck('name').join(', '), currentPath);
+      log('\nFound %s in "%s"', _(res.markdownFiles).pluck('name').join(', '), currentPath);
     else 
-      console.log('\nFound nothing in "%s"', currentPath);
+      log('\nFound nothing in "%s"', currentPath);
 
     return { 
       markdownFiles :  res.markdownFiles,


### PR DESCRIPTION
To use this tool in combination with others, I found it useful to have a option which allows to pipe the output of  a single file transform to stdout instead a file.

Changes:
* Added `output` variable, which can be either file or stdout
* Added `log()` and `logError()` functions so that no debugging messages are written to stdout if `output` is set to `stdout`

Example Usage:

    doctoc README.md --stdout