### PR TITLE
Custom-TOC-title and max-heading-level options added, argument parsing improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ by github or other sites via a command line flag.
   - [Using doctoc to generate links compatible with other sites](#using-doctoc-to-generate-links-compatible-with-other-sites)
     - [Example](#example-1)
   - [Specifying location of toc](#specifying-location-of-toc)
+  - [Specifying a custom TOC title](#specifying-a-custom-toc-title)
+  - [Specifying a maximum heading level for TOC entries](#specifying-a-maximum-heading-level-for-toc-entries)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -95,4 +97,17 @@ Here we'll discuss...
 
 ```
 
-Running doctoc will insert the toc to that location.
+Running doctoc will insert the toc at that location.
+
+### Specifying a custom TOC title
+
+Use the `--title` option to specify a (Markdown-formatted) custom TOC title; e.g., `doctoc --title '**Contents**' .`
+
+### Specifying a maximum heading level for TOC entries
+
+Use the `--maxlevel` option to limit TOC entries to headings only up to the specified level; e.g., `doctoc --maxlevel 3 .`
+
+By default, 
+
+* no limit is placed on Markdown-formatted headings,
+* whereas headings from embedded HTML are limited to 4 levels.

--- a/doctoc.js
+++ b/doctoc.js
@@ -4,9 +4,9 @@
 
 var path      =  require('path')
   , fs        =  require('fs')
+  , minimist  =  require('minimist')
   , file      =  require('./lib/file')
   , transform =  require('./lib/transform')
-  , argv      =  process.argv
   , files;
 
 function cleanPath(path) {
@@ -16,13 +16,13 @@ function cleanPath(path) {
   return homeExpanded.replace(/\s/g, '\\ ');
 }
 
-function transformAndSave(files, mode) {
+function transformAndSave(files, mode, maxHeaderLevel, title) {
   console.log('\n==================\n');
   
   var transformed = files
     .map(function (x) {
       var content = fs.readFileSync(x.path, 'utf8')
-        , result = transform(content, mode);
+        , result = transform(content, mode, maxHeaderLevel, title);
       result.path = x.path;
       return result;
     });
@@ -39,36 +39,55 @@ function transformAndSave(files, mode) {
   });
 }
 
-var modes = [ 
-  [ 'bitbucket', 'bitbucket.org' ]
-, [ 'nodejs'   , 'nodejs.org'    ]
-, [ 'github'   , 'github.com'    ]
-, [ 'gitlab'   , 'gitlab.com'    ]
-, [ 'ghost'    , 'ghost.org'     ]
-];
+function printUsageAndExit(isErr) {
+  
+  var outputFunc = isErr ? console.error : console.info;
 
-var mode = 'github.com'
-
-if (argv.length < 3) {
-  console.error('Usage: doctoc [mode] <path> (where path is some path to a directory (i.e. .) or a file (i.e. README.md) )');
-  console.error('\nAvailable modes are:');
-  for (var i = 0; i < modes.length; i++) {
-    console.error('  --%s\t%s', modes[i][0], modes[i][1]);
+  outputFunc('Usage: doctoc [mode] [--title title] [--maxlevel level] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
+  outputFunc('\nAvailable modes are:');
+  for (var key in modes) {
+    outputFunc('  --%s\t%s', key, modes[key]);
   }
-  console.error('Defaults to \'github.com\'.')
-  process.exit(0);
+  outputFunc('Defaults to \'' + mode + '\'.');
+
+  process.exit(isErr ? 2 : 0);
 }
 
-for (var i = 0; i < modes.length; i++) {
-  var idx = argv.indexOf('--' + modes[i][0]);
-  if (~idx) {
-    mode = modes[i][1];
-    argv.splice(idx, 1);
-    break;
+var modes = {
+    bitbucket: 'bitbucket.org'
+  , nodejs: 'nodejs.org'
+  , github:    'github.com'
+  , gitlab:    'gitlab.com'
+  , ghost:     'ghost.org'
+}
+
+var mode = modes['github'];
+
+var argv = minimist(process.argv.slice(2)
+    , { boolean: [ 'h', 'help' ].concat(Object.keys(modes))
+    , string: [ 'title', 't', 'maxlevel', 'm' ]
+    , unknown: function(a) { return (a[0] == '-' ? (console.error('Unknown option(s): ' + a), printUsageAndExit(true)) : true); }
+    });
+
+if (argv.h || argv.help) {
+  printUsageAndExit();
+} else if (argv._.length != 1) {
+  console.error('Please specify exactly one file or directory path.');
+  printUsageAndExit(true);
+}
+
+for (var key in modes) {
+  if (argv[key]) {
+    mode = modes[key];
   }
 }
 
-var target = cleanPath(argv[2])
+var title = argv.t || argv.title;
+
+var maxHeaderLevel = argv.m || argv.maxlevel;
+if (maxHeaderLevel && isNaN(maxHeaderLevel) || maxHeaderLevel < 0) { console.error('Max. heading level specified is not a positive number: ' + maxHeaderLevel), printUsageAndExit(true); }
+
+var target = cleanPath(argv._[0])
   , stat = fs.statSync(target)
 
 if (stat.isDirectory()) {
@@ -79,6 +98,6 @@ if (stat.isDirectory()) {
   files = [{ path: target }];
 }
 
-transformAndSave(files, mode);
+transformAndSave(files, mode, maxHeaderLevel, title);
 
 console.log('\nEverything is OK.');

--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -35,7 +35,7 @@ function rankify(headers, max) {
     })
 }
 
-var go = module.exports = function (lines, maxHeaderNo) {
+var go = module.exports = function (lines, maxHeaderLevel) {
   var md = lines.join('\n');
   var headers = [], grabbing = null, text = [];
 
@@ -65,6 +65,6 @@ var go = module.exports = function (lines, maxHeaderNo) {
 
   headers = addLinenos(lines, headers)
   // consider anything past h4 to small to warrant a link, may be made configurable in the future
-  headers = rankify(headers, maxHeaderNo);
+  headers = rankify(headers, maxHeaderLevel);
   return headers;
 }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -25,7 +25,7 @@ function addAnchor(mode, header) {
 }
 
 
-function getHashedHeaders (lines) {
+function getHashedHeaders (lines, maxHeaderLevel) {
   var inCodeBlock = false
     , lineno = 0;
 
@@ -48,7 +48,7 @@ function getHashedHeaders (lines) {
     .map(function (x) {
       var match = /^(\#{1,8})[ ]*(.+)\r?$/.exec(x.line);
 
-      return match 
+      return match && (!maxHeaderLevel || match[1].length <= maxHeaderLevel)
         ? { rank :  match[1].length
           , name :  normalize(match[2])
           , line :  x.lineno
@@ -58,7 +58,7 @@ function getHashedHeaders (lines) {
     .filter(notNull)
 }
 
-function getUnderlinedHeaders (lines) {
+function getUnderlinedHeaders (lines, maxHeaderLevel) {
     // Find headers of the form
     // h1       h2
     // ==       --
@@ -72,11 +72,13 @@ function getUnderlinedHeaders (lines) {
         else if (/^--+ *\r?$/.exec(line)) rank = 2;
         else                              return null;
 
-        return {
-          rank  :  rank,
-          name  :  lines_[index - 1],
-          line  :  index - 1
-        };
+        return !maxHeaderLevel || (rank <= maxHeaderLevel)
+          ? {
+              rank  :  rank,
+              name  :  lines_[index - 1],
+            line  :  index - 1
+            }
+          : null;
       })
       .filter(notNull)
 }
@@ -112,9 +114,10 @@ function getLinesToToc (lines, currentToc, info) {
   return lines.slice(tocableStart);
 }
 
-exports = module.exports = function transform(content, mode, maxHeaderNo) {
+exports = module.exports = function transform(content, mode, maxHeaderLevel, title) {
   mode = mode || 'github.com';
-  maxHeaderNo = maxHeaderNo || 4;
+  var maxHeaderLevelHtml = maxHeaderLevel || 4; // only limit *HTML* headings by default
+  title = title || '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*';
 
   var lines = content.split('\n')
     , info = updateSection.parse(lines, matchesStart, matchesEnd)
@@ -122,9 +125,9 @@ exports = module.exports = function transform(content, mode, maxHeaderNo) {
   var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx).join('\n')
     , linesToToc = getLinesToToc(lines, currentToc, info);
 
-  var headers = getHashedHeaders(linesToToc)
-    .concat(getUnderlinedHeaders(linesToToc))
-    .concat(getHtmlHeaders(linesToToc, maxHeaderNo))
+  var headers = getHashedHeaders(linesToToc, maxHeaderLevel)
+    .concat(getUnderlinedHeaders(linesToToc, maxHeaderLevel))
+    .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml))
 
   headers.sort(function (a, b) {
     return a.line - b.line;
@@ -140,7 +143,7 @@ exports = module.exports = function transform(content, mode, maxHeaderNo) {
   var indentation = mode === 'bitbucket.org' ? '    ' : '  ';
 
   var toc =
-      '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*'
+      title
     + '\n\n'
     + linkedHeaders
         .map(function (x) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "anchor-markdown-header": "^0.5.0",
     "htmlparser2": "~3.7.1",
+    "minimist": "^1.1.0",
     "underscore": ">=1.3.3",
     "update-section": "^0.3.0"
   },

--- a/test/transform-html.js
+++ b/test/transform-html.js
@@ -4,7 +4,7 @@
 var test = require('tap').test
   , transform = require('../lib/transform')
 
-test('\ngiven a file that includes html with header tags and maxHeaderNo 8', function (t) {
+test('\ngiven a file that includes html with header tags and maxHeaderLevel 8', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-html.md', 'utf8');
   var headers = transform(content, 'github.com', 8);
 
@@ -29,7 +29,7 @@ test('\ngiven a file that includes html with header tags and maxHeaderNo 8', fun
   t.end()
 })
 
-test('\ngiven a file that includes html with header tags using default maxHeaderNo', function (t) {
+test('\ngiven a file that includes html with header tags using default maxHeaderLevel', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-html.md', 'utf8');
   var headers = transform(content);
 
@@ -44,7 +44,7 @@ test('\ngiven a file that includes html with header tags using default maxHeader
         '    - [dockops::Containers::clean(id, cb)](#dockopscontainerscleanid-cb)',
         '- [License](#license)',
         '' ]
-    , 'generates correct toc for non html and html headers omitting headers larger than maxHeaderNo'
+    , 'generates correct toc for non html and html headers omitting headers larger than maxHeaderLevel'
   )
   t.end()
 })

--- a/test/transform.js
+++ b/test/transform.js
@@ -8,9 +8,9 @@ function inspect(obj, depth) {
   console.log(require('util').inspect(obj, false, depth || 5, true));
 }
 
-function check(md, anchors, mode) {
+function check(md, anchors, mode, maxHeaderLevel, title) {
   test('transforming ' + md , function (t) {
-    var res = transform(md, mode)
+    var res = transform(md, mode, maxHeaderLevel, title)
 
     // remove wrapper
     var data = res.data.split('\n');
@@ -158,6 +158,66 @@ check(
     , '- [In the Right Order 2](#in-the-right-order-2)\n\n\n'
     ].join('')
 )
+
+check(
+    [ '# Heading'
+    , ''
+    , 'Custom TOC title test'
+    ].join('\n')
+  , [ '**Contents**\n\n'
+    , '- [Heading](#heading)\n\n\n'
+    ].join('')
+  , undefined
+  , undefined
+  , '**Contents**'
+)
+
+check(
+    [ '# H1h'
+    , '## H2h'
+    , '### H3h'
+    , ''
+    , 'Max. level test - hashed'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [H1h](#h1h)\n'
+    , '  - [H2h](#h2h)\n\n\n'
+    ].join('')
+  , undefined
+  , 2
+)
+
+check(
+    [ 
+      'H1u'
+    , '==='
+    , 'H2u'
+    , '---'
+    , ''
+    , 'Max. level test - underlined'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [H1u](#h1u)\n\n\n'
+    ].join('')
+  , undefined
+  , 1
+)
+
+check(
+    [ 
+      '<html><head></head><body>'
+    , '<h1>H1html</h1><h2>H2html</h2><h3>H3html</h3>'
+    , '</body></html>'
+    , 'Max. level test - HTML'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [H1html](#h1html)\n'
+    , '  - [H2html](#h2html)\n\n\n'
+    ].join('')
+  , undefined
+  , 2
+)
+
 
 test('transforming when old toc exists', function (t) {
   var md = [ 


### PR DESCRIPTION
* You can now specify a custom TOC title with `--title <title>`.
* You can now limit TOC entries to a max. heading level with `--maxlevel <level>`.
  * Note: For backward compatibility, headings extracted from HTML are limited to 4 levels - no such constraint is based on Markdown headings.
* Argument parsing improved by switching to the 'minimist' library.
  * Now supports `-h` and `--help` and reports syntax errors,