### PR TITLE
Bugfix: Crashes if a header is `hasOwnProperty`

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -89,7 +89,8 @@ function countHeaders (headers) {
     var header = headers[i];
     var name = header.name;
 
-    if (instances.hasOwnProperty(name)) {
+    if (Object.prototype.hasOwnProperty.call(instances, name)) {
+      // `instances.hasOwnProperty(name)` fails when there’s an instance named "hasOwnProperty".
       instances[name]++;
     } else {
       instances[name] = 0;

--- a/test/fixtures/readme-with-weird-headers.md
+++ b/test/fixtures/readme-with-weird-headers.md
@@ -1,0 +1,14 @@
+README to test doctoc with edge-case headers.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [hasOwnProperty](#hasownproperty)
+- [something else](#something-else)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## hasOwnProperty
+## something else

--- a/test/transform-weird-headers.js
+++ b/test/transform-weird-headers.js
@@ -1,0 +1,22 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test
+  , transform = require('../lib/transform');
+
+test('\ngiven a file with edge-case header names', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-weird-headers.md', 'utf8');
+  var headers = transform(content);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [ '## Table of Contents',
+        '',
+        '- [hasOwnProperty](#hasownproperty)',
+        '- [something else](#something-else)',
+        '' ]
+    , 'generates a correct toc when headers are weird'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
True story: <https://github.com/1-liners/1-liners/commit/c087021>.