### PR TITLE
Parse headers as markdown (issues #69 #73)

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -3,7 +3,8 @@
 var _             = require('underscore')
   , anchor        = require('anchor-markdown-header')
   , updateSection = require('update-section')
-  , getHtmlHeaders = require('./get-html-headers');
+  , getHtmlHeaders = require('./get-html-headers')
+  , md            = require('markdown-to-ast');
 
 var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
             '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'
@@ -24,62 +25,39 @@ function addAnchor(mode, header) {
   return header;
 }
 
+function isString(y) {
+  return typeof y === 'string';
+}
 
-function getHashedHeaders (lines, maxHeaderLevel) {
-  var inCodeBlock = false
-    , lineno = 0;
 
-  // Turn all headers into '## xxx' even if they were '## xxx ##'
-  function normalize(header) {
-    return header.replace(/[ #]+$/, '');
+function getMarkdownHeaders (lines, maxHeaderLevel) {
+  function extractText (header) {
+    return header.children
+      .filter(function (x) {
+        return x.type !== 'Image';
+      })
+      .map(function (x) {
+        if (x.type === 'Link') {
+          return extractText(x);
+        }
+        return x.raw;
+      })
+      .join('')
   }
 
-  // Find headers of the form '### xxxx xxx xx [###]'
-  return lines
-    .map(function (x, idx) {
-      return { lineno: idx, line: x }
-    })
+  return md.parse(lines.join('\n')).children
     .filter(function (x) {
-      if (x.line.match(/^```/)) {
-        inCodeBlock = !inCodeBlock;
-      }
-      return !inCodeBlock;
+      return x.type === 'Header';
     })
     .map(function (x) {
-      var match = /^(\#{1,8})[ ]*(.+)\r?$/.exec(x.line);
-
-      return match && (!maxHeaderLevel || match[1].length <= maxHeaderLevel)
-        ? { rank :  match[1].length
-          , name :  normalize(match[2])
-          , line :  x.lineno
+      return !maxHeaderLevel || x.depth <= maxHeaderLevel
+        ? { rank :  x.depth
+          , name :  extractText(x)
+          , line :  x.loc.start.line
           }
         : null;
     })
     .filter(notNull)
-}
-
-function getUnderlinedHeaders (lines, maxHeaderLevel) {
-    // Find headers of the form
-    // h1       h2
-    // ==       --
-
-    return lines
-      .map(function (line, index, lines_) {
-        if (index === 0) return null;
-        var rank;
-
-        if (/^==+ *\r?$/.exec(line))      rank = 1;
-        else if (/^--+ *\r?$/.exec(line)) rank = 2;
-        else                              return null;
-
-        return !maxHeaderLevel || (rank <= maxHeaderLevel)
-          ? { rank  :  rank
-            , name  :  lines_[index - 1]
-            , line  :  index - 1
-            }
-          : null;
-      })
-      .filter(notNull)
 }
 
 function countHeaders (headers) {
@@ -136,8 +114,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
   var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx).join('\n')
     , linesToToc = getLinesToToc(lines, currentToc, info);
 
-  var headers = getHashedHeaders(linesToToc, maxHeaderLevel)
-    .concat(getUnderlinedHeaders(linesToToc, maxHeaderLevel))
+  var headers = getMarkdownHeaders(linesToToc, maxHeaderLevel)
     .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml))
 
   headers.sort(function (a, b) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "anchor-markdown-header": "^0.5.4",
     "htmlparser2": "~3.7.1",
+    "markdown-to-ast": "~3.0.5",
     "minimist": "~1.1.0",
     "underscore": ">=1.3.3",
     "update-section": "^0.3.0"


### PR DESCRIPTION
Parse markdown headers to grab the wanted text, even if markdown is embedded within the header. Especially if the header has links or inline images.

See #73 for explanation.