### PR TITLE
strip code blocks before parsing headers - #38

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -26,8 +26,7 @@ function addAnchor(mode, header) {
 
 
 function getHashedHeaders (lines, maxHeaderLevel) {
-  var inCodeBlock = false
-    , lineno = 0;
+  var lineno = 0;
 
   // Turn all headers into '## xxx' even if they were '## xxx ##'
   function normalize(header) {
@@ -38,12 +37,6 @@ function getHashedHeaders (lines, maxHeaderLevel) {
   return lines
     .map(function (x, idx) {
       return { lineno: idx, line: x }
-    })
-    .filter(function (x) {
-      if (x.line.match(/^```/)) {
-        inCodeBlock = !inCodeBlock;
-      }
-      return !inCodeBlock;
     })
     .map(function (x) {
       var match = /^(\#{1,8})[ ]*(.+)\r?$/.exec(x.line);
@@ -123,18 +116,28 @@ function determineTitle(title, notitle, lines, info) {
   return info.hasStart ? lines[info.startIdx + 2] : defaultTitle;
 }
 
+// Remove code blocks so that false headers are not parsed
+function stripCodeBlocks(content) {
+  return content
+    .replace(/```([\s\S]*?)```/g, '') // must be before single backtick check
+    .replace(/`([\s\S]*?)`/g, '')
+    .replace(/<code>([\s\S]*?)<\/code>/g, '')
+    .replace(/<pre>([\s\S]*?)<\/pre>/g, '');
+}
+
 exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle) {
   mode = mode || 'github.com';
   // only limit *HTML* headings by default
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
 
   var lines = content.split('\n')
+    , linesForHeaderParsing = stripCodeBlocks(content).split('\n')
     , info = updateSection.parse(lines, matchesStart, matchesEnd)
 
   var inferredTitle = determineTitle(title, notitle, lines, info);
 
   var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx).join('\n')
-    , linesToToc = getLinesToToc(lines, currentToc, info);
+    , linesToToc = getLinesToToc(linesForHeaderParsing, currentToc, info);
 
   var headers = getHashedHeaders(linesToToc, maxHeaderLevel)
     .concat(getUnderlinedHeaders(linesToToc, maxHeaderLevel))

--- a/test/fixtures/readme-with-code.md
+++ b/test/fixtures/readme-with-code.md
@@ -1,0 +1,37 @@
+README to test doctoc with edge-case headers.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Single Backticks](#single-backticks)
+- [Multiple Backticks](#multiple-backticks)
+- [code tag](#code-tag)
+- [pre tag](#pre-tag)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Single Backticks
+`<h2>Single Backticks</h2>`
+`## Single Backticks`
+
+## Multiple Backticks
+```
+<h2>Multiple Backticks</h2>
+## Multiple Backticks
+Multiple Backticks
+------------------
+```
+
+## code tag
+<code><h2>code tag</h2></code>
+<code>## code tag</code>
+
+## pre tag
+<pre>
+    <h2>pre tag</h2>
+    ## pre tag
+    pre tag
+    -------
+</pre>

--- a/test/transform-code.js
+++ b/test/transform-code.js
@@ -1,0 +1,24 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test
+  , transform = require('../lib/transform');
+
+test('\ngiven a file with headers embedded in code', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-code.md', 'utf8');
+  var headers = transform(content);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [ '## Table of Contents',
+        '',
+        '- [Single Backticks](#single-backticks)',
+        '- [Multiple Backticks](#multiple-backticks)',
+        '- [code tag](#code-tag)',
+        '- [pre tag](#pre-tag)',
+        '' ]
+    , 'generates a correct toc when headers are embedded in code blocks'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
I've fixed #38 by stripping out the 4 types of markdown code blocks before parsing headers. In doing this, I removed the previous method which filtered out triple-backticked lines during parsing (was only done for parsing hashed headers). Test case included. Let me know if you'd prefer fixing this in some other way. It's worth noting that badly-formed markdown files will break... but presumably they would break anyway.