### PR TITLE
[Docker]: Provide a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine
+
+ENTRYPOINT ["doctoc"]
+CMD []
+
+VOLUME /source
+
+RUN apk -U add nodejs && \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /app
+COPY . /app
+
+RUN npm install -g doctoc
+
+WORKDIR /source


### PR DESCRIPTION
Provilde a [Dockerfile](https://docs.docker.com/engine/reference/builder/) for easier use in Docker-based enviornments where one _does not_ want to necessarily polluate their system with various NodeJS dependencies just to run this lovely tool1
