### PR TITLE
Parse headers as markdown (bugs fixed)

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -3,7 +3,8 @@
 var _             = require('underscore')
   , anchor        = require('anchor-markdown-header')
   , updateSection = require('update-section')
-  , getHtmlHeaders = require('./get-html-headers');
+  , getHtmlHeaders = require('./get-html-headers')
+  , md            = require('markdown-to-ast');
 
 var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
             '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'
@@ -24,62 +25,44 @@ function addAnchor(mode, header) {
   return header;
 }
 
+function isString(y) {
+  return typeof y === 'string';
+}
 
-function getHashedHeaders (lines, maxHeaderLevel) {
-  var inCodeBlock = false
-    , lineno = 0;
 
-  // Turn all headers into '## xxx' even if they were '## xxx ##'
-  function normalize(header) {
-    return header.replace(/[ #]+$/, '');
+function getMarkdownHeaders (lines, maxHeaderLevel) {
+  function extractText (header) {
+    return header.children
+      .map(function (x) {
+        if (x.type === md.Syntax.Link) {
+          return extractText(x);
+        }
+        else if (x.type === md.Syntax.Image) {
+          // Images (at least on GitHub, untested elsewhere) are given a hyphen
+          // in the slug. We can achieve this behavior by adding an '*' to the
+          // TOC entry. Think of it as a "magic char" that represents the iamge.
+          return '*';
+        }
+        else {
+          return x.raw;
+        }
+      })
+      .join('')
   }
 
-  // Find headers of the form '### xxxx xxx xx [###]'
-  return lines
-    .map(function (x, idx) {
-      return { lineno: idx, line: x }
-    })
+  return md.parse(lines.join('\n')).children
     .filter(function (x) {
-      if (x.line.match(/^```/)) {
-        inCodeBlock = !inCodeBlock;
-      }
-      return !inCodeBlock;
+      return x.type === md.Syntax.Header;
     })
     .map(function (x) {
-      var match = /^(\#{1,8})[ ]*(.+)\r?$/.exec(x.line);
-
-      return match && (!maxHeaderLevel || match[1].length <= maxHeaderLevel)
-        ? { rank :  match[1].length
-          , name :  normalize(match[2])
-          , line :  x.lineno
+      return !maxHeaderLevel || x.depth <= maxHeaderLevel
+        ? { rank :  x.depth
+          , name :  extractText(x)
+          , line :  x.loc.start.line
           }
         : null;
     })
     .filter(notNull)
-}
-
-function getUnderlinedHeaders (lines, maxHeaderLevel) {
-    // Find headers of the form
-    // h1       h2
-    // ==       --
-
-    return lines
-      .map(function (line, index, lines_) {
-        if (index === 0) return null;
-        var rank;
-
-        if (/^==+ *\r?$/.exec(line))      rank = 1;
-        else if (/^--+ *\r?$/.exec(line)) rank = 2;
-        else                              return null;
-
-        return !maxHeaderLevel || (rank <= maxHeaderLevel)
-          ? { rank  :  rank
-            , name  :  lines_[index - 1]
-            , line  :  index - 1
-            }
-          : null;
-      })
-      .filter(notNull)
 }
 
 function countHeaders (headers) {
@@ -109,7 +92,7 @@ function getLinesToToc (lines, currentToc, info) {
 
   // when updating an existing toc, we only take the headers into account
   // that are below the existing toc
-  if (info.hasEnd) tocableStart = info.endIdx;
+  if (info.hasEnd) tocableStart = info.endIdx + 1;
 
   return lines.slice(tocableStart);
 }
@@ -133,11 +116,10 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
 
   var inferredTitle = determineTitle(title, notitle, lines, info);
 
-  var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx).join('\n')
+  var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx + 1).join('\n')
     , linesToToc = getLinesToToc(lines, currentToc, info);
 
-  var headers = getHashedHeaders(linesToToc, maxHeaderLevel)
-    .concat(getUnderlinedHeaders(linesToToc, maxHeaderLevel))
+  var headers = getMarkdownHeaders(linesToToc, maxHeaderLevel)
     .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml))
 
   headers.sort(function (a, b) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "anchor-markdown-header": "^0.5.4",
     "htmlparser2": "~3.7.1",
+    "markdown-to-ast": "~3.0.5",
     "minimist": "~1.1.0",
     "underscore": ">=1.3.3",
     "update-section": "^0.3.0"

--- a/test/fixtures/readme-with-nested-markdown.md
+++ b/test/fixtures/readme-with-nested-markdown.md
@@ -1,0 +1,18 @@
+# [CNN](https://www.cnn.com)
+
+This header's a link to another site. We want to just show the link's text, not
+the link URL.
+
+# Get Involved [![Gitter chat](https://badges.gitter.im/Cockatrice/Cockatrice.png)](https://gitter.im/Cockatrice/Cockatrice)
+
+Chat with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.
+
+# Translation Status [![Cockatrice on Transiflex](https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png)](https://www.transifex.com/projects/p/cockatrice/)
+
+Cockatrice uses Transifex for translations. You can help us bring Cockatrice/Oracle to your language or edit single wordings by clicking on the associated charts below.<br>
+Our [project page](https://www.transifex.com/projects/p/cockatrice/) offers a detailed overview for contributors.
+
+# Building [![Build Status](https://travis-ci.org/Cockatrice/Cockatrice.svg?branch=master)](https://travis-ci.org/Cockatrice/Cockatrice)
+
+**Detailed installation instructions are on the Cockatrice wiki under [Installing Cockatrice](https://github.com/Cockatrice/Cockatrice/wiki/Installing-Cockatrice)**
+

--- a/test/transform-nested-markdown.js
+++ b/test/transform-nested-markdown.js
@@ -1,0 +1,28 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test
+  , transform = require('../lib/transform');
+
+test('\nhandle inline links and images', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-nested-markdown.md', 'utf8');
+  var headers = transform(content, null, null, '', false);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '- [CNN](#cnn)',
+        '- [Get Involved *](#get-involved-)',
+        '- [Translation Status *](#translation-status-)',
+        '- [Building *](#building-)',
+        '',
+      ]
+    , 'generates correct toc for nested markdown (links and images)'
+  )
+  t.end()
+});
+
+
+


### PR DESCRIPTION
This pull request is a continuation of #77, as it looks like that PR has
gone stale. It concluded with a note that the tests didn't seem to pass,
so I've fixed the failing tests, made the changes necessary to fix #69
and #73, and added tests verifying that they work as expected.

The root of the failing tests in #77 was that `markdown-to-ast` (which
uses Remark under the hood) was incorrectly parsing this snippet of
Markdown:

    <!-- comment -->
    ## Header

This came up because we were misusing the `#parse` method of the
thlorenz/update-section library we're using: endIdx is actually an
_inclusive_ index, but we were using it as an exclusive index. (As an
aside, during the process I also discovered a bug in update-section,
which I will report in a separate PR. It does not affect this PR nor
doctoc in general).

I've not squashed the commits intentionally so that you can see what's
been changed between this and #77. When you've reviewed it and it looks
good I'll be sure to do so.