### PR TITLE
Strip code blocks before html parser

### DIFF
--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -35,8 +35,18 @@ function rankify(headers, max) {
     })
 }
 
+// Remove code blocks so that false headers are not parsed
+function stripMDCodeBlocks(content) {
+  return content
+    .replace(/```([\s\S]*?)```/g, '') // must be before single backtick check
+    .replace(/`([\s\S]*?)`/g, '')
+    .replace(/<code>([\s\S]*?)<\/code>/g, '')
+    .replace(/<pre>([\s\S]*?)<\/pre>/g, '');
+}
+
 var go = module.exports = function (lines, maxHeaderLevel) {
   var md = lines.join('\n');
+  var source = stripMDCodeBlocks(md);
   var headers = [], grabbing = null, text = [];
 
   var parser = new htmlparser.Parser({
@@ -60,7 +70,7 @@ var go = module.exports = function (lines, maxHeaderLevel) {
   },
   { decodeEntities: true })
 
-  parser.write(md);
+  parser.write(source);
   parser.end();
 
   headers = addLinenos(lines, headers)

--- a/test/fixtures/readme-with-code.md
+++ b/test/fixtures/readme-with-code.md
@@ -1,0 +1,37 @@
+README to test doctoc with edge-case headers.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Single Backticks](#single-backticks)
+- [Multiple Backticks](#multiple-backticks)
+- [code tag](#code-tag)
+- [pre tag](#pre-tag)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Single Backticks
+`<h2>Single Backticks</h2>`
+`## Single Backticks`
+
+## Multiple Backticks
+```
+<h2>Multiple Backticks</h2>
+## Multiple Backticks
+Multiple Backticks
+------------------
+```
+
+## code tag
+<code><h2>code tag</h2></code>
+<code>## code tag</code>
+
+## pre tag
+<pre>
+    <h2>pre tag</h2>
+    ## pre tag
+    pre tag
+    -------
+</pre>

--- a/test/transform-html.js
+++ b/test/transform-html.js
@@ -48,3 +48,22 @@ test('\ngiven a file that includes html with header tags using default maxHeader
   )
   t.end()
 })
+
+test('\ngiven a file with headers embedded in code', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-code.md', 'utf8');
+  var headers = transform(content);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [ '## Table of Contents',
+        '',
+        '- [Single Backticks](#single-backticks)',
+        '- [Multiple Backticks](#multiple-backticks)',
+        '- [code tag](#code-tag)',
+        '- [pre tag](#pre-tag)',
+        '' ]
+    , 'generates a correct toc when headers are embedded in code blocks'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Fix #38 and #88 with @yomed 's #82 added only to html header parser 