### PR TITLE
Upgrade markdown-to-ast

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "anchor-markdown-header": "^0.5.4",
     "htmlparser2": "~3.7.1",
-    "markdown-to-ast": "~3.0.5",
+    "markdown-to-ast": "~3.2.3",
     "minimist": "~1.1.0",
     "underscore": ">=1.3.3",
     "update-section": "^0.3.0"

--- a/test/fixtures/readme-nameless-table-headers.md
+++ b/test/fixtures/readme-nameless-table-headers.md
@@ -1,0 +1,9 @@
+# Heading One
+
+| | |
+| --- | --- |
+| foo | bar |
+
+The columns above don't have titles; they're just empty.
+
+## Subheading 2

--- a/test/transform-weird-headers.js
+++ b/test/transform-weird-headers.js
@@ -20,3 +20,21 @@ test('\ngiven a file with edge-case header names', function (t) {
 
   t.end()
 })
+
+test('\nnameless table headers', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-nameless-table-headers.md', 'utf8');
+  var headers = transform(content);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '- [Heading One](#heading-one)',
+        '  - [Subheading 2](#subheading-2)',
+        '' ]
+    , 'generates a correct toc when readme has nameless table headers'
+  )
+
+  t.end()
+})
+


### PR DESCRIPTION
Fixes #94.

An upstream bug was affecting our usage of markdown-to-ast. It was fixed
upstream, so we're upgrading our dependency to the latest version.

We also add a minimal test readme that previously failed and which no
longer fails after the change.