### PR TITLE
Use markdown + html parsers to detect codeblocks

### DIFF
--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var htmlparser = require('htmlparser2');
+var htmlparser = require('htmlparser2')
+  , md         = require('markdown-to-ast');
 
 function addLinenos(lines, headers) {
   var current = 0, line;
@@ -36,31 +37,47 @@ function rankify(headers, max) {
 }
 
 var go = module.exports = function (lines, maxHeaderLevel) {
-  var md = lines.join('\n');
-  var headers = [], grabbing = null, text = [];
+  var source = md.parse(lines.join('\n'))
+    .children
+    .filter(function(node) {
+      return node.type === md.Syntax.HtmlBlock || node.type === md.Syntax.Html;
+    })
+    .map(function (node) {
+      return node.raw;
+    })
+    .join('\n');
+
+  //var headers = [], grabbing = null, text = [];
+  var headers = [], grabbing = [], text = [];
 
   var parser = new htmlparser.Parser({
     onopentag: function (name, attr) {
-      if ((/h\d/).test(name)) {
-        grabbing = name;
+      // Short circuit if we're already inside a pre
+      if (grabbing[grabbing.length - 1] === 'pre') return;
+
+      if (name === 'pre' || (/h\d/).test(name)) {
+        grabbing.push(name);
       }
     },
     ontext: function (text_) {
-      if (!grabbing) return;
+      // Explicitly skip pre tags, and implicitly skip all others
+      if (grabbing.length === 0 ||
+          grabbing[grabbing.length - 1] === 'pre') return;
+
       text.push(text_);
     },
     onclosetag: function (name) {
-      if (!grabbing) return;
-      if (grabbing === name) {
-        headers.push({ text: text, tag: grabbing });
-        grabbing = null;
+      if (grabbing.length === 0) return;
+      if (grabbing[grabbing.length - 1] === name) {
+        var tag = grabbing.pop();
+        headers.push({ text: text, tag: tag });
         text = [];
       }
     }
   },
   { decodeEntities: true })
 
-  parser.write(md);
+  parser.write(source);
   parser.end();
 
   headers = addLinenos(lines, headers)

--- a/test/fixtures/readme-benign-backticks.md
+++ b/test/fixtures/readme-benign-backticks.md
@@ -1,0 +1,13 @@
+# Hello, world!
+
+> You can make code blocks with three back ticks:
+>
+> ```
+
+# Add this header
+
+<h1>And also this one</h1>
+
+> ```
+
+

--- a/test/fixtures/readme-with-code.md
+++ b/test/fixtures/readme-with-code.md
@@ -1,0 +1,37 @@
+README to test doctoc with edge-case headers.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Single Backticks](#single-backticks)
+- [Multiple Backticks](#multiple-backticks)
+- [code tag](#code-tag)
+- [pre tag](#pre-tag)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Single Backticks
+`<h2>not me single backticks</h2>`
+`## nor me single backticks`
+
+## Multiple Backticks
+```
+<h2>not me fenced</h2>
+## nor me fenced
+not even me fenced
+------------------
+```
+
+## code tag
+<code><h2>not me code</h2></code>
+<code>## nor me code</code>
+
+## pre tag
+<pre>
+    <h2>not me pre</h2>
+    ## nor me pre
+    not even me pre
+    -------
+</pre>

--- a/test/transform-html.js
+++ b/test/transform-html.js
@@ -48,3 +48,40 @@ test('\ngiven a file that includes html with header tags using default maxHeader
   )
   t.end()
 })
+
+test('\ngiven a file with headers embedded in code', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-code.md', 'utf8');
+  var headers = transform(content);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [ '## Table of Contents',
+        '',
+        '- [Single Backticks](#single-backticks)',
+        '- [Multiple Backticks](#multiple-backticks)',
+        '- [code tag](#code-tag)',
+        '- [pre tag](#pre-tag)',
+        '' ]
+    , 'generates a correct toc when headers are embedded in code blocks'
+  )
+
+  t.end()
+})
+
+test('\ngiven a file with benign backticks', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-benign-backticks.md', 'utf8');
+  var headers = transform(content);
+
+  t.deepEqual(
+      headers.toc.split('\n')
+    , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '- [Hello, world!](#hello-world)',
+        '- [Add this header](#add-this-header)',
+        '- [And also this one](#and-also-this-one)',
+        '' ]
+    , 'generates a correct toc when readme has benign backticks'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
**Relevant Issues**

Fixes #37, #38, #84, #88, #99.

**Summary of Changes**

This commit builds upon the markdown-to-ast integration we added in #91,
using markdown-to-ast in `lib/get-html-headers.js`.

We first filter our lines to only look for HTML sections (using the
markdown parser), then in these HTML-only sections, we search for headers,
as long as they're not inside pre tags.

This is accomplished by keeping a stack of tags we've descended through. We
can peek at the top of the stack to see if we're directly under a
`pre` tag, meaning we should ignore everything until we see the closing
`pre`. Otherwise, we can collect text from inside heading tags as normal.

Thus, the core changes in this commit are:

- `grabbing` is a stack now, instead of a string
- `markdown-to-ast` lets us filter for only HTML blocks
- `htmlparser2` lets us check if we're inside a heading *or* pre tag

**Test Plan**

This pull request adds two passing tests:

- one that makes sure we eliminate bad headings nested in pre tags, and
- one that would fail a non-robust, regex-based search for code blocks,
  excluding headings that should have been included

Basically, the first checks for false positives, and the second checks
for false negatives.