### PR TITLE
Peg anchor-markdown-header to ^0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=0.4"
   },
   "dependencies": {
-    "anchor-markdown-header": "^0.5.4",
+    "anchor-markdown-header": "^0.5.5",
     "htmlparser2": "~3.7.1",
     "markdown-to-ast": "~3.2.3",
     "minimist": "~1.1.0",


### PR DESCRIPTION
Fixes #81.
Fixes #104.

This version of `anchor-markdown-header` includes changes that
correctly handle '@' signs in headers.