### PR TITLE
Added option for stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,8 @@ By default,
 - no limit is placed on Markdown-formatted headings,
 - whereas headings from embedded HTML are limited to 4 levels.
 
+### Printing to stdout
+
+You can print to stdout by using the `-s` or `--stdout` option.
+
 [ack]: http://beyondgrep.com/

--- a/doctoc.js
+++ b/doctoc.js
@@ -16,9 +16,9 @@ function cleanPath(path) {
   return homeExpanded.replace(/\s/g, '\\ ');
 }
 
-function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix) {
+function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, stdOut) {
   console.log('\n==================\n');
-  
+
   var transformed = files
     .map(function (x) {
       var content = fs.readFileSync(x.path, 'utf8')
@@ -27,15 +27,26 @@ function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPref
       return result;
     });
   var changed = transformed.filter(function (x) { return x.transformed; })
-    , unchanged = transformed.filter(function (x) { return !x.transformed; });
+    , unchanged = transformed.filter(function (x) { return !x.transformed; })
+    , toc = transformed.filter(function (x) { return x.toc; })
+
+  if (stdOut) {
+    toc.forEach(function (x) {
+      console.log(x.toc)
+    })
+  }
 
   unchanged.forEach(function (x) {
     console.log('"%s" is up to date', x.path);
   });
 
   changed.forEach(function (x) { 
-    console.log('"%s" will be updated', x.path);
-    fs.writeFileSync(x.path, x.data, 'utf8'); 
+    if (stdOut) {
+      console.log('==================\n\n"%s" should be updated', x.path)
+    } else {
+      console.log('"%s" will be updated', x.path);
+      fs.writeFileSync(x.path, x.data, 'utf8'); 
+    }
   });
 }
 
@@ -64,7 +75,7 @@ var modes = {
 var mode = modes['github'];
 
 var argv = minimist(process.argv.slice(2)
-    , { boolean: [ 'h', 'help', 'T', 'notitle'].concat(Object.keys(modes))
+    , { boolean: [ 'h', 'help', 'T', 'notitle', 's', 'stdout'].concat(Object.keys(modes))
     , string: [ 'title', 't', 'maxlevel', 'm', 'entryprefix' ]
     , unknown: function(a) { return (a[0] == '-' ? (console.error('Unknown option(s): ' + a), printUsageAndExit(true)) : true); }
     });
@@ -82,6 +93,7 @@ for (var key in modes) {
 var title = argv.t || argv.title;
 var notitle = argv.T || argv.notitle;
 var entryPrefix = argv.entryprefix || '-';
+var stdOut = argv.s || argv.stdout
 
 var maxHeaderLevel = argv.m || argv.maxlevel;
 if (maxHeaderLevel && isNaN(maxHeaderLevel) || maxHeaderLevel < 0) { console.error('Max. heading level specified is not a positive number: ' + maxHeaderLevel), printUsageAndExit(true); }
@@ -98,7 +110,7 @@ for (var i = 0; i < argv._.length; i++) {
     files = [{ path: target }];
   }
 
-  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix);
+  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, stdOut);
 
   console.log('\nEverything is OK.');
 }

--- a/test/fixtures/stdout.md
+++ b/test/fixtures/stdout.md
@@ -1,0 +1,16 @@
+
+DocToccing single file "test/fixtures/readme-with-custom-title.md" for github.com.
+
+==================
+
+## Table of Contents
+
+- [Installation](#installation)
+- [API](#api)
+- [License](#license)
+
+==================
+
+"test/fixtures/readme-with-custom-title.md" should be updated
+
+Everything is OK.

--- a/test/transform-stdout.js
+++ b/test/transform-stdout.js
@@ -1,0 +1,36 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test,
+    fs = require('fs'),
+    exec = require("child_process").exec;
+
+test('\nshould print to stdout with --stdout option', function (t) {
+
+    exec('node doctoc.js test/fixtures/readme-with-custom-title.md --stdout', function (error, stdout, stderr) {
+      if (error) {
+        console.error('exec error: ', error);
+        return;
+      }
+      t.deepEqual(stdout
+        , fs.readFileSync(__dirname + '/fixtures/stdout.md', 'utf8')
+        , 'spits out the correct table of contents')
+
+      t.end()
+    })
+})
+
+test('\nshould print to stdout with -s option', function (t) {
+
+    exec('node doctoc.js test/fixtures/readme-with-custom-title.md -s', function (error, stdout, stderr) {
+      if (error) {
+        console.error('exec error: ', error);
+        return;
+      }
+      t.deepEqual(stdout
+        , fs.readFileSync(__dirname + '/fixtures/stdout.md', 'utf8')
+        , 'spits out the correct table of contents')
+
+      t.end()
+    })
+})


### PR DESCRIPTION
By adding the `-s` or `--stdout` option, you can print to stdout now. Not the most beautiful PR, but I think it is pretty efficient and it works for me. Let me know if I can edit anything!

Related to issue #100