### PR TITLE
Added flag for only updating files that already contain doctoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ by github or other sites via a command line flag.
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
 ## Installation
 
     npm install -g doctoc
@@ -52,7 +51,16 @@ specified](#using-doctoc-to-generate-links-compatible-with-other-sites).
 
 ### Update existing doctoc TOCs effortlessly
 
-If you already have a TOC inserted by doctoc, it will automatically be updated by running the command (rather than inserting a duplicate toc). Doctoc locates the TOC by the `<!-- START doctoc -->` and `<!-- END doctoc -->` comments, so you can also move a generated TOC to any other portion of your document and it will be updated there.
+If you already have a TOC inserted by doctoc, it will automatically be updated 
+by running the command (rather than inserting a duplicate toc).
+Doctoc locates the TOC by the `<!-- START doctoc -->` and `<!-- END doctoc -->` comments, 
+so you can also move a generated TOC to any other portion of your document and it will be updated there.
+
+You can tell doctoc to **only update** files that **already** have a TOC 
+(including those that [specify location of toc](#specifying-location-of-toc)),
+by adding the `--explicit` flag:
+
+    doctoc . --explicit
 
 ### Adding toc to individual files
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -106,7 +106,7 @@ function determineTitle(title, notitle, lines, info) {
   return info.hasStart ? lines[info.startIdx + 2] : defaultTitle;
 }
 
-exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix) {
+exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, explicit) {
   mode = mode || 'github.com';
   entryPrefix = entryPrefix || '-';
 
@@ -115,6 +115,10 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
 
   var lines = content.split('\n')
     , info = updateSection.parse(lines, matchesStart, matchesEnd)
+
+  if (explicit && !info.hasStart) {
+    return { transformed: false };
+  }
 
   var inferredTitle = determineTitle(title, notitle, lines, info);
 

--- a/test/transform-explicit.js
+++ b/test/transform-explicit.js
@@ -1,0 +1,76 @@
+'use strict'
+/*jshint asi: true */
+
+var test = require('tap').test
+  , transform = require('../lib/transform')
+
+test('\nwith explicit flag content is not transformed', function (t) {
+  var content = [
+    '# Header one',
+    '## Header two'
+  ].join('\n')
+  var result = transform(content, null, null, null, false, null, true)
+  t.deepEqual(result, {transformed: false}, 'because no `START doctoc` found')
+  t.end()
+})
+
+test('\nwith explicit flag content is transformed', function (t) {
+  var content = [
+    '<!-- START doctoc -->',
+    '<!-- END doctoc -->',
+    '# Header one',
+    '## Header two'
+  ].join('\n')
+  var result = transform(content, null, null, null, false, null, true)
+
+  t.deepEqual(
+    result.toc.split('\n'), [
+      '# Header one',
+      '',
+      '- [Header one](#header-one)',
+      '  - [Header two](#header-two)',
+      ''
+    ], 'because `START doctoc` and `END doctoc` found'
+  )
+  t.end()
+})
+
+test('\nwithout explicit flag content is transformed', function (t) {
+  var content = [
+    '# Header one',
+    '## Header two'
+  ].join('\n')
+  var result = transform(content, null, null, null, false, null, false)
+
+  t.deepEqual(
+    result.toc.split('\n'), [
+      '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+      '',
+      '- [Header one](#header-one)',
+      '  - [Header two](#header-two)',
+      ''
+    ], 'because `START doctoc` and `END doctoc` found'
+  )
+  t.end()
+})
+
+test('\nwithout explicit flag content is transformed', function (t) {
+  var content = [
+    '<!-- START doctoc -->',
+    '<!-- END doctoc -->',
+    '# Header one',
+    '## Header two'
+  ].join('\n')
+  var result = transform(content, null, null, null, false, null, false)
+
+  t.deepEqual(
+    result.toc.split('\n'), [
+      '# Header one',
+      '',
+      '- [Header one](#header-one)',
+      '  - [Header two](#header-two)',
+      ''
+    ], 'when `START doctoc` and `END doctoc` found'
+  )
+  t.end()
+})


### PR DESCRIPTION
This PR allows the use of the flag `--explicit` (or `-e`).
With the flag only files already containing `START doctoc` will get updated.

This adds the feature requested in #80.

As mentioned in the ticket I'm willing to change the name of the flag, please suggest one if the one I chose doesn't work for you.

Open tasks
- [x] add documentation in README
- [x] add tests (not sure how to, after looking at the current test suite)
- [x] incorporate review feedback