### PR TITLE
Handle file skipping internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ by the markdown parser. Doctoc defaults to using the GitHub parser, but other
 [modes can be
 specified](#using-doctoc-to-generate-links-compatible-with-other-sites).
 
+### Ignoring individual files
+In order to ignore a specific file when running `doctoc` on an entire directory, just add `<!-- DOCTOC SKIP -->` to the top of the file you wish to ignore.
 
 ### Update existing doctoc TOCs effortlessly
 
@@ -65,14 +67,6 @@ If you want to convert only specific files, do:
     doctoc README.md
 
     doctoc CONTRIBUTING.md LICENSE.md
-
-You can use this feature to do more sophisticated things. For example, if you
-have [ack][ack] installed, you could add `<!-- DOCTOC SKIP -->` to specific
-files and then use
-
-    ack -L 'DOCTOC SKIP' | xargs doctoc
-
-to recompile only those files which don't have the DOCTOC SKIP comment.
 
 ### Using doctoc to generate links compatible with other sites
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -9,6 +9,8 @@ var _             = require('underscore')
 var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
             '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'
   , end   = '<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
+  , skipTag = '<!-- DOCTOC SKIP -->';
+
 
 function matchesStart(line) {
   return (/<!-- START doctoc /).test(line);
@@ -107,6 +109,8 @@ function determineTitle(title, notitle, lines, info) {
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix) {
+  if (content.indexOf(skipTag) !== -1) return { transformed: false };
+
   mode = mode || 'github.com';
   entryPrefix = entryPrefix || '-';
 


### PR DESCRIPTION
The current solution for skipping files is to have a system utility such
as `ack` handle the searching for you.  This is not ideal because it
makes the documentation not as clear and ads a dependancies in some
cases.

Here we have the library handle skipping files, but simply not
transforming files that contain the tag