### PR TITLE
Collapse consecutive blank lines if there's no title

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Running doctoc will insert the toc at that location.
 
 Use the `--title` option to specify a (Markdown-formatted) custom TOC title; e.g., `doctoc --title '**Contents**' .` From then on, you can simply run `doctoc <file>` and doctoc will will keep the title you specified.
 
-Alternatively, to blank out the title with a newline, use the `--notitle` option. This will simply remove the title from the TOC.
+Alternatively, to blank out the title, use the `--notitle` option. This will simply remove the title from the TOC.
 
 ### Specifying a maximum heading level for TOC entries
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -118,6 +118,8 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
 
   var inferredTitle = determineTitle(title, notitle, lines, info);
 
+  var titleSeparator = inferredTitle ? '\n\n' : '\n';
+
   var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx + 1).join('\n')
     , linesToToc = getLinesToToc(lines, currentToc, info);
 
@@ -139,7 +141,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
 
   var toc =
       inferredTitle
-    + '\n\n'
+    + titleSeparator
     + linkedHeaders
         .map(function (x) {
           var indent = _(_.range(x.rank - lowestRank))

--- a/test/transform-title.js
+++ b/test/transform-title.js
@@ -45,7 +45,6 @@ test('\nclobber existing title', function (t) {
   t.deepEqual(
       headers.toc.split('\n')
     , [ '',
-        '',
         '- [Installation](#installation)',
         '- [API](#api)',
         '- [License](#license)',


### PR DESCRIPTION
Closes #101

## before

    # example

    <!-- START doctoc generated TOC please keep comment here to allow auto update -->
    <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


    - [NAME](#name)
    - [SYNOPSIS](#synopsis)
    - [DESCRIPTION](#description)
    - [EXPORTS](#exports)
      - [foo](#foo)
      - [bar](#bar)
      - [baz](#baz)
    - [SEE ALSO](#see-also)
    - [AUTHOR](#author)
    - [COPYRIGHT AND LICENSE](#copyright-and-license)

    <!-- END doctoc generated TOC please keep comment here to allow auto update -->

## after

    # example

    <!-- START doctoc generated TOC please keep comment here to allow auto update -->
    <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

    - [NAME](#name)
    - [SYNOPSIS](#synopsis)
    - [DESCRIPTION](#description)
    - [EXPORTS](#exports)
      - [foo](#foo)
      - [bar](#bar)
      - [baz](#baz)
    - [SEE ALSO](#see-also)
    - [AUTHOR](#author)
    - [COPYRIGHT AND LICENSE](#copyright-and-license)

    <!-- END doctoc generated TOC please keep comment here to allow auto update -->