### PR TITLE
Replace markdown-to-ast with @textlint/markdown-to-ast

### DIFF
--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var htmlparser = require('htmlparser2')
-  , md         = require('markdown-to-ast');
+  , md         = require('@textlint/markdown-to-ast');
 
 function addLinenos(lines, headers) {
   var current = 0, line;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -4,7 +4,7 @@ var _             = require('underscore')
   , anchor        = require('anchor-markdown-header')
   , updateSection = require('update-section')
   , getHtmlHeaders = require('./get-html-headers')
-  , md            = require('markdown-to-ast');
+  , md            = require('@textlint/markdown-to-ast');
 
 var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
             '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "node": ">=0.4"
   },
   "dependencies": {
+    "@textlint/markdown-to-ast": "~6.0.9",
     "anchor-markdown-header": "^0.5.5",
     "htmlparser2": "~3.9.2",
-    "markdown-to-ast": "~3.4.0",
     "minimist": "~1.2.0",
     "underscore": "~1.8.3",
     "update-section": "^0.3.0"


### PR DESCRIPTION
Fixes #148

Just replaced the dependency, all tests are still passing as well
