### PR TITLE
Resolve #148 deprecation of markdown-to-ast (passes all tests)

### DIFF
--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var htmlparser = require('htmlparser2')
-  , md         = require('markdown-to-ast');
+  , md         = require('@textlint/markdown-to-ast');
 
 function addLinenos(lines, headers) {
   var current = 0, line;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -4,7 +4,7 @@ var _             = require('underscore')
   , anchor        = require('anchor-markdown-header')
   , updateSection = require('update-section')
   , getHtmlHeaders = require('./get-html-headers')
-  , md            = require('markdown-to-ast');
+  , md            = require('@textlint/markdown-to-ast');
 
 var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
             '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "anchor-markdown-header": "^0.5.5",
     "htmlparser2": "~3.9.2",
-    "markdown-to-ast": "~3.4.0",
+    "@textlint/markdown-to-ast": "~6.0.9",
     "minimist": "~1.2.0",
     "underscore": "~1.8.3",
     "update-section": "^0.3.0"


### PR DESCRIPTION
Seems to work just fine.

**Testoutput:**
```
> doctoc@1.3.1 test /tmp/doctoc
> set -e; for t in test/*.js; do node $t; done

TAP version 13
# Subtest:  given a file that includes html with header tags and maxHeaderLevel 8
    ok 1 - generates correct toc for non html and html headers
    1..1
ok 1 -  given a file that includes html with header tags and maxHeaderLevel 8 # time=49.339ms

# Subtest:  given a file that includes html with header tags using default maxHeaderLevel
    ok 1 - generates correct toc for non html and html headers omitting headers larger than maxHeaderLevel
    1..1
ok 2 -  given a file that includes html with header tags using default maxHeaderLevel # time=29.697ms

# Subtest:  given a file with headers embedded in code
    ok 1 - generates a correct toc when headers are embedded in code blocks
    1..1
ok 3 -  given a file with headers embedded in code # time=7.939ms

# Subtest:  given a file with benign backticks
    ok 1 - generates a correct toc when readme has benign backticks
    1..1
ok 4 -  given a file with benign backticks # time=3.476ms

1..4
# time=105.057ms
TAP version 13
# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 1 - transforming # time=19.954ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 2 - transforming # time=5.989ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 3 - transforming # time=1.885ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 4 - transforming # time=3.194ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 5 - transforming # time=2.628ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 6 - transforming # time=1.436ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 7 - transforming # time=1.759ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 8 - transforming # time=1.511ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 9 - transforming # time=1.432ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 10 - transforming # time=1.26ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 11 - transforming # time=1.544ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 12 - transforming # time=1.452ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 13 - transforming # time=2.65ms

# Subtest: transforming when old toc exists
    ok 1 - transforms it
    ok 2 - replaces old toc
    ok 3 - wraps old toc
    ok 4 - updates the content with the new toc and ignores header before existing toc
    1..4
ok 14 - transforming when old toc exists # time=1.821ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 15 - transforming # time=3.009ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 16 - transforming # time=4.238ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 17 - transforming # time=2.939ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 18 - transforming # time=3.602ms

# Subtest: transforming
    ok 1 - transforms it
    ok 2 - generates correct anchors
    1..2
ok 19 - transforming # time=5.848ms

1..19
# time=116.336ms
TAP version 13
# Subtest:  handle inline links and images
    ok 1 - generates correct toc for nested markdown (links and images)
    1..1
ok 1 -  handle inline links and images # time=22.733ms

1..1
# time=29.331ms
TAP version 13
# Subtest:  should print to stdout with --stdout option
    ok 1 - spits out the correct table of contents
    1..1
ok 1 -  should print to stdout with --stdout option # time=145.017ms

# Subtest:  should print to stdout with -s option
    ok 1 - spits out the correct table of contents
    1..1
ok 2 -  should print to stdout with -s option # time=237.584ms

1..2
# time=391.231ms
TAP version 13
# Subtest:  overwrite existing title
    ok 1 - generates correct toc for when custom --title was passed
    1..1
ok 1 -  overwrite existing title # time=27.443ms

# Subtest:  do not overwrite existing title
    ok 1 - generates correct toc for when custom title exists in README already
    1..1
ok 2 -  do not overwrite existing title # time=5.283ms

# Subtest:  clobber existing title
    ok 1 - generates correct toc for when --notitle was passed
    1..1
ok 3 -  clobber existing title # time=4.098ms

1..3
# time=53.102ms
TAP version 13
# Subtest:  given a file with edge-case header names
    ok 1 - generates a correct toc when headers are weird
    1..1
ok 1 -  given a file with edge-case header names # time=19.613ms

# Subtest:  nameless table headers
    ok 1 - generates a correct toc when readme has nameless table headers
    1..1
ok 2 -  nameless table headers # time=15.488ms

1..2
# time=46.966ms
```