### PR TITLE
fixed path (minor)

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -10,10 +10,7 @@ var path      =  require('path')
   , files;
 
 function cleanPath(path) {
-  var homeExpanded = (path.indexOf('~') === 0) ? process.env.HOME + path.substr(1) : path;
-
-  // Escape all spaces
-  return homeExpanded.replace(/\s/g, '\\ ');
+  return homeExpanded = (path.indexOf('~') === 0) ? process.env.HOME + path.substr(1) : path;
 }
 
 function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, stdOut) {


### PR DESCRIPTION
Fixed the path name convention as mentioned in https://github.com/thlorenz/doctoc/issues/158#issuecomment-487272123

```bash
$ doctoc Extra\ Headers.md

DocToccing single file "Extra Headers.md" for github.com.

==================

"Extra Headers.md" will be updated

Everything is OK.
```