### PR TITLE
Don't transform files whose TOC is unchanged

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -152,7 +152,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
 
   var wrappedToc =  start + '\n' + toc + '\n' + end;
 
-  if (currentToc === toc) return { transformed: false };
+  if (currentToc === wrappedToc) return { transformed: false };
 
   var data = updateSection(lines.join('\n'), wrappedToc, matchesStart, matchesEnd, true);
   return { transformed : true, data : data, toc: toc, wrappedToc: wrappedToc };

--- a/test/fixtures/readme-with-code.md
+++ b/test/fixtures/readme-with-code.md
@@ -4,10 +4,7 @@ README to test doctoc with edge-case headers.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Single Backticks](#single-backticks)
-- [Multiple Backticks](#multiple-backticks)
-- [code tag](#code-tag)
-- [pre tag](#pre-tag)
+Out of date
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/test/fixtures/readme-with-custom-title.md
+++ b/test/fixtures/readme-with-custom-title.md
@@ -6,9 +6,7 @@ README to test doctoc with user-specified titles.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Installation](#installation)
-- [API](#api)
-- [License](#license)
+Out of date
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/test/fixtures/readme-with-weird-headers.md
+++ b/test/fixtures/readme-with-weird-headers.md
@@ -4,8 +4,7 @@ README to test doctoc with edge-case headers.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [hasOwnProperty](#hasownproperty)
-- [something else](#something-else)
+Out of date
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
Looking at the code, this was always the intention, but there was a small bug in the logic that this PR fixes. Some tests needed to be updated, because they relied on the fact that even unchanged TOC was reported as transformed.

This is helpful e.g. to check in CI that all TOCs have been updated, like this:

    doctoc --stdout . | grep -q "should be updated" && echo "TOCs are out of date!"