### PR TITLE
Updated Precommit field to most recent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ following configuration:
 ```yaml
 repos:
 -   repo: https://github.com/thlorenz/doctoc
-    sha: ...  # substitute a tagged version
+    rev: ...  # substitute a tagged version
     hooks:
     -   id: doctoc
 ```


### PR DESCRIPTION
Precommit v1.7 changed the field from `sha` to `rev`: https://pre-commit.com/#pre-commit-configyaml---repos