### PR TITLE
pre-commit docs: update sha -> rev

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ following configuration:
 ```yaml
 repos:
 -   repo: https://github.com/thlorenz/doctoc
-    sha: ...  # substitute a tagged version
+    rev: ...  # substitute a tagged version
     hooks:
     -   id: doctoc
 ```


### PR DESCRIPTION
Since pre-commit [v1.7.0](https://github.com/pre-commit/pre-commit/blob/master/CHANGELOG.md#170---2018-03-03), `rev` is the preferred spelling for that field