### PR TITLE
add --entire flag

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -16,13 +16,13 @@ function cleanPath(path) {
   return homeExpanded.replace(/\s/g, '\\ ');
 }
 
-function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, stdOut) {
+function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, entire, stdOut) {
   console.log('\n==================\n');
 
   var transformed = files
     .map(function (x) {
       var content = fs.readFileSync(x.path, 'utf8')
-        , result = transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix);
+        , result = transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, entire);
       result.path = x.path;
       return result;
     });
@@ -54,7 +54,7 @@ function printUsageAndExit(isErr) {
 
   var outputFunc = isErr ? console.error : console.info;
 
-  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
+  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--entire] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
   outputFunc('\nAvailable modes are:');
   for (var key in modes) {
     outputFunc('  --%s\t%s', key, modes[key]);
@@ -75,7 +75,7 @@ var modes = {
 var mode = modes['github'];
 
 var argv = minimist(process.argv.slice(2)
-    , { boolean: [ 'h', 'help', 'T', 'notitle', 's', 'stdout'].concat(Object.keys(modes))
+    , { boolean: [ 'h', 'help', 'T', 'notitle', 's', 'stdout', 'entire' ].concat(Object.keys(modes))
     , string: [ 'title', 't', 'maxlevel', 'm', 'entryprefix' ]
     , unknown: function(a) { return (a[0] == '-' ? (console.error('Unknown option(s): ' + a), printUsageAndExit(true)) : true); }
     });
@@ -93,6 +93,7 @@ for (var key in modes) {
 var title = argv.t || argv.title;
 var notitle = argv.T || argv.notitle;
 var entryPrefix = argv.entryprefix || '-';
+var entire = argv.entire;
 var stdOut = argv.s || argv.stdout
 
 var maxHeaderLevel = argv.m || argv.maxlevel;
@@ -110,7 +111,7 @@ for (var i = 0; i < argv._.length; i++) {
     files = [{ path: target }];
   }
 
-  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, stdOut);
+  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, entire, stdOut);
 
   console.log('\nEverything is OK.');
 }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -85,8 +85,8 @@ function countHeaders (headers) {
   return headers;
 }
 
-function getLinesToToc (lines, currentToc, info) {
-  if (!currentToc) return lines;
+function getLinesToToc (lines, currentToc, info, entire) {
+  if (entire || !currentToc) return lines;
 
   var tocableStart = 0;
 
@@ -106,7 +106,7 @@ function determineTitle(title, notitle, lines, info) {
   return info.hasStart ? lines[info.startIdx + 2] : defaultTitle;
 }
 
-exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix) {
+exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, entire) {
   mode = mode || 'github.com';
   entryPrefix = entryPrefix || '-';
 
@@ -119,7 +119,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
   var inferredTitle = determineTitle(title, notitle, lines, info);
 
   var currentToc = info.hasStart && lines.slice(info.startIdx, info.endIdx + 1).join('\n')
-    , linesToToc = getLinesToToc(lines, currentToc, info);
+    , linesToToc = getLinesToToc(lines, currentToc, info, entire);
 
   var headers = getMarkdownHeaders(linesToToc, maxHeaderLevel)
     .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml))


### PR DESCRIPTION
`<!-- START doctoc -->` and `<!-- END doctoc -->` are described as the indicator of TOC location,
but it actually affects TOC generating and it's not documented.

In case we have a line `<!-- START doctoc -->` at the middle of the document,
headings above the line will be omitted from generated TOC:

```markdown
# Heading 1
heading 1

<!-- START doctoc -->
<!-- END doctoc -->

# Heading 2
heading 2
```

```markdown
# Heading 1
heading 1

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


- [Heading 2](#heading-2)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

# Heading 2
heading 2
```

I'm not sure this behaviour is intended or not, but, anyway, it's better making this configurable.

This PR adds `--entire` flag to CLI.
With `--entire` flag, the above example will generate the TOC includes headings above
`<!-- START doctoc -->` line:

```markdown
# Heading 1
heading 1

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


- [Heading 1](#heading-1)
- [Heading 2](#heading-2)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

# Heading 2
heading 2
```
