### PR TITLE
Upgrade `anchor-markdown-header` to fix emoji-titled headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -329,11 +329,11 @@
       }
     },
     "anchor-markdown-header": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
-      "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz",
+      "integrity": "sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==",
       "requires": {
-        "emoji-regex": "~6.1.0"
+        "emoji-regex": "~10.1.0"
       }
     },
     "ansi-regex": {
@@ -701,9 +701,9 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
-      "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI="
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg=="
     },
     "entities": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": "doctoc.js",
   "dependencies": {
     "@textlint/markdown-to-ast": "^12.1.1",
-    "anchor-markdown-header": "^0.5.7",
+    "anchor-markdown-header": "^0.6.0",
     "htmlparser2": "^7.2.0",
     "minimist": "^1.2.6",
     "underscore": "^1.13.2",

--- a/test/fixtures/readme-emoji-headers.md
+++ b/test/fixtures/readme-emoji-headers.md
@@ -1,0 +1,20 @@
+README to test doctoc with emoji-first headers
+
+<!-- START doctoc -->
+<!-- END doctoc -->
+
+# 🔴 or 🟡 - At Risk
+
+# 🔄 Still Need Updates
+
+## ⏱ Past-Due Items
+
+# ➡ ETA Changes This Week
+
+# 🚀 Shipped this week
+
+# 🛠 Availability repair items
+
+# 🎟 Support Tickets
+
+# 🔬 Team-by-team Breakdown: Hello

--- a/test/transform-weird-headers.js
+++ b/test/transform-weird-headers.js
@@ -38,3 +38,25 @@ test('\nnameless table headers', function (t) {
   t.end()
 })
 
+test('\nemoji-first header names', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-emoji-headers.md', 'utf8');
+  var headers = transform(content);
+
+  t.same(
+      headers.toc.split('\n')
+    , [ '',
+        '- [🔴 or 🟡 - At Risk](#-or----at-risk)',
+        '- [🔄 Still Need Updates](#-still-need-updates)',
+        '  - [⏱ Past-Due Items](#-past-due-items)',
+        '- [➡ ETA Changes This Week](#-eta-changes-this-week)',
+        '- [🚀 Shipped this week](#-shipped-this-week)',
+        '- [🛠 Availability repair items](#-availability-repair-items)',
+        '- [🎟 Support Tickets](#-support-tickets)',
+        '- [🔬 Team-by-team Breakdown: Hello](#-team-by-team-breakdown-hello)',
+        '' ]
+    , 'generates a correct toc when readme has emojis as the first character for headings'
+  )
+
+  t.end()
+})
+


### PR DESCRIPTION
### Add test for emoji-titled headers

This provides an example of the problem described in https://github.com/thlorenz/doctoc/issues/191.

### Add launch.json to enable test debugging

For codespaces/VS Code. This was very helpful in diagnosing https://github.com/thlorenz/doctoc/issues/191.

Based on approach taken in https://stackoverflow.com/a/39607924, though the port stuff wasn't necessary anymore.

### Upgrade anchor-markdown-header to fix emoji-titled headers 

Actually fixes #191