### PR TITLE
fix: formatted headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -329,11 +329,12 @@
       }
     },
     "anchor-markdown-header": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz",
-      "integrity": "sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.7.0.tgz",
+      "integrity": "sha512-OYUgo5tYN+WipGB2R3sZUvXLpTzqSnm0b3AXRqN9Rhi2Z+uCQsFSguDDgpoSdhDrnu/aCYHFGHosdL9hbaWSHA==",
       "requires": {
-        "emoji-regex": "~10.1.0"
+        "emoji-regex": "~10.1.0",
+        "remove-markdown": "^0.5.0"
       }
     },
     "ansi-regex": {
@@ -1707,6 +1708,11 @@
       "requires": {
         "mdast-util-from-markdown": "^0.8.0"
       }
+    },
+    "remove-markdown": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.0.tgz",
+      "integrity": "sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg=="
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": "doctoc.js",
   "dependencies": {
     "@textlint/markdown-to-ast": "^12.1.1",
-    "anchor-markdown-header": "^0.6.0",
+    "anchor-markdown-header": "^0.7.0",
     "htmlparser2": "^7.2.0",
     "minimist": "^1.2.6",
     "underscore": "^1.13.2",

--- a/test/fixtures/readme-with-formatted-headers.md
+++ b/test/fixtures/readme-with-formatted-headers.md
@@ -1,0 +1,9 @@
+<!-- START doctoc -->
+<!-- END doctoc -->
+
+## foo _bar_
+## foo **baz**
+## foo ~baf~
+## bar_foo
+## baz_foo_
+## _foo_bax_

--- a/test/transform-weird-headers.js
+++ b/test/transform-weird-headers.js
@@ -60,3 +60,23 @@ test('\nemoji-first header names', function (t) {
   t.end()
 })
 
+
+test('\nformatted headers', function (t) {
+  var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-formatted-headers.md', 'utf8');
+  var headers = transform(content);
+
+  t.same(
+      headers.toc.split('\n')
+    , [ '',
+        '- [foo _bar_](#foo-bar)',
+        '- [foo **baz**](#foo-baz)',
+        '- [foo ~baf~](#foo-baf)',
+        '- [bar_foo](#bar_foo)',
+        '- [baz_foo_](#baz_foo_)',
+        '- [_foo_bax_](#foo_bax)',
+        '' ]
+    , 'generates a correct toc when readme includes formatting in the heading title'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Really appreciate this package!

Running into this problem. Currently, headers like 

```md
# foo _bar_
```

are transformed into this TOC entry:

```md
- [foo _bar_](#foo-_bar_)
```

But the actual anchor generated by GitHub is `foo-bar` and the TOC links break. [Here's a sample](https://github.com/hongaar/moker)

~I've added a test to demonstrate this, not quite sure where to start fixing this. I ended up in the [`extractText`](https://github.com/thlorenz/doctoc/blob/bb8296004340eb186406764d7ed1b6edb74fa12a/lib/transform.js#L36) function, however now I'm thinking maybe this should be fixed in https://github.com/thlorenz/anchor-markdown-header?~

~Any help is appreciated.~

**EDIT** This is now addressed with https://github.com/thlorenz/anchor-markdown-header/pull/48. If that lands I will update this PR.