### PR TITLE
chore: run tests with tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib-cov
+.nyc_output
 *.seed
 *.log
 *.csv

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/thlorenz/doctoc.git"
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tap"
   },
   "files": [
     "lib"
@@ -36,5 +36,8 @@
     "bitbucket",
     "gitlab",
     "ghost"
-  ]
+  ],
+  "tap": {
+    "check-coverage": false
+  }
 }

--- a/test/transform-html.js
+++ b/test/transform-html.js
@@ -8,7 +8,7 @@ test('\ngiven a file that includes html with header tags and maxHeaderLevel 8', 
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-html.md', 'utf8');
   var headers = transform(content, 'github.com', 8);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
         '',
@@ -33,7 +33,7 @@ test('\ngiven a file that includes html with header tags using default maxHeader
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-html.md', 'utf8');
   var headers = transform(content);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
         '',
@@ -53,7 +53,7 @@ test('\ngiven a file with headers embedded in code', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-code.md', 'utf8');
   var headers = transform(content);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '## Table of Contents',
         '',
@@ -72,7 +72,7 @@ test('\ngiven a file with benign backticks', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-benign-backticks.md', 'utf8');
   var headers = transform(content);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
         '',

--- a/test/transform-nested-markdown.js
+++ b/test/transform-nested-markdown.js
@@ -8,7 +8,7 @@ test('\nhandle inline links and images', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-nested-markdown.md', 'utf8');
   var headers = transform(content, null, null, '', false);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [
         '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',

--- a/test/transform-skipTag.js
+++ b/test/transform-skipTag.js
@@ -8,7 +8,7 @@ test('\nskip file transform', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-skipTag.md', 'utf8');
   var transformedContent = transform(content);
 
-  t.deepEqual(
+  t.same(
     transformedContent.toc
     , undefined
     , 'skip correct file'

--- a/test/transform-stdout.js
+++ b/test/transform-stdout.js
@@ -12,7 +12,7 @@ test('\nshould print to stdout with --stdout option', function (t) {
         console.error('exec error: ', error);
         return;
       }
-      t.deepEqual(stdout
+      t.same(stdout
         , fs.readFileSync(__dirname + '/fixtures/stdout.md', 'utf8')
         , 'spits out the correct table of contents')
 
@@ -27,7 +27,7 @@ test('\nshould print to stdout with -s option', function (t) {
         console.error('exec error: ', error);
         return;
       }
-      t.deepEqual(stdout
+      t.same(stdout
         , fs.readFileSync(__dirname + '/fixtures/stdout.md', 'utf8')
         , 'spits out the correct table of contents')
 

--- a/test/transform-title.js
+++ b/test/transform-title.js
@@ -8,7 +8,7 @@ test('\noverwrite existing title', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-custom-title.md', 'utf8');
   var headers = transform(content, null, null, '## Table of Contents', false);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '## Table of Contents',
         '',
@@ -25,7 +25,7 @@ test('\ndo not overwrite existing title', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-custom-title.md', 'utf8');
   var headers = transform(content, null, null, null, false);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '## Table of Contents',
         '',
@@ -42,7 +42,7 @@ test('\nclobber existing title', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-custom-title.md', 'utf8');
   var headers = transform(content, null, null, null, true);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '',
         '- [Installation](#installation)',

--- a/test/transform-weird-headers.js
+++ b/test/transform-weird-headers.js
@@ -8,7 +8,7 @@ test('\ngiven a file with edge-case header names', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-weird-headers.md', 'utf8');
   var headers = transform(content);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '## Table of Contents',
         '',
@@ -25,7 +25,7 @@ test('\nnameless table headers', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-nameless-table-headers.md', 'utf8');
   var headers = transform(content);
 
-  t.deepEqual(
+  t.same(
       headers.toc.split('\n')
     , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
         '',

--- a/test/transform.js
+++ b/test/transform.js
@@ -28,7 +28,7 @@ function check(md, anchors, mode, maxHeaderLevel, title, notitle, entryPrefix, p
       .concat(mdLines);
 
     t.ok(res.transformed, 'transforms it');
-    t.deepEqual(data, rig, 'generates correct anchors')
+    t.same(data, rig, 'generates correct anchors')
     t.end()
   })
 }
@@ -242,7 +242,7 @@ test('transforming when old toc exists', function (t) {
 
   t.ok(res.transformed, 'transforms it')     
 
-  t.deepEqual(
+  t.same(
       res.toc.split('\n')
     , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
       '',
@@ -251,7 +251,7 @@ test('transforming when old toc exists', function (t) {
     , 'replaces old toc' 
   )
   
-  t.deepEqual(
+  t.same(
       res.wrappedToc.split('\n')
     , [ '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
         '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
@@ -264,7 +264,7 @@ test('transforming when old toc exists', function (t) {
     , 'wraps old toc'
   )
 
-  t.deepEqual(
+  t.same(
       res.data.split('\n')
     , [ '# Header above',
         '',
@@ -307,7 +307,7 @@ test('transforming when old toc exists and --all flag is set', function (t) {
 
   t.ok(res.transformed, 'transforms it')     
 
-  t.deepEqual(
+  t.same(
       res.toc.split('\n')
     , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
       '',
@@ -317,7 +317,7 @@ test('transforming when old toc exists and --all flag is set', function (t) {
     , 'replaces old toc' 
   )
   
-  t.deepEqual(
+  t.same(
       res.wrappedToc.split('\n')
     , [ '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
         '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
@@ -331,7 +331,7 @@ test('transforming when old toc exists and --all flag is set', function (t) {
     , 'wraps old toc'
   )
 
-  t.deepEqual(
+  t.same(
       res.data.split('\n')
     , [ '# Header above',
         '',


### PR DESCRIPTION
- Replaced `deepEqual` (deprecated) with [`same`](https://node-tap.org/docs/api/asserts/#tsamefound-wanted-message-extra).
- Replaced test script with `tap` for console output with rainbows (disable `test-coverage` in `package.json` so we don't need the default 100% coverage to not fail the tests).