### PR TITLE
fix: Properly handle files with whitespace

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -12,8 +12,7 @@ var path      =  require('path')
 function cleanPath(path) {
   var homeExpanded = (path.indexOf('~') === 0) ? process.env.HOME + path.substr(1) : path;
 
-  // Escape all spaces
-  return homeExpanded.replace(/\s/g, '\\ ');
+  return homeExpanded;
 }
 
 function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly) {


### PR DESCRIPTION
A bisect confirmed that this was introduced from commit 994839f1cb5e2c4c75ba712f5de4cc3aa4438919.

Closes #89
Closes #127
Closes #158 