### PR TITLE
fix: Improve `cleanPath` platform compatability

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -4,13 +4,14 @@
 
 var path      =  require('path')
   , fs        =  require('fs')
+  , os        =  require('os')
   , minimist  =  require('minimist')
   , file      =  require('./lib/file')
   , transform =  require('./lib/transform')
   , files;
 
 function cleanPath(path) {
-  var homeExpanded = (path.indexOf('~') === 0) ? process.env.HOME + path.substr(1) : path;
+  var homeExpanded = (path.indexOf('~') === 0) ? path.join(os.homedir() + path.substr(1)) : path;
 
   // Escape all spaces
   return homeExpanded.replace(/\s/g, '\\ ');


### PR DESCRIPTION
Uses `os.homedir()` since that works better on non-POSIXy platforms.

I know this code uses old conventions and methods, so if NodeJS version compatability is a concern, these are when these functions were added to NodeJS:

- [os.homedir](https://nodejs.org/dist/latest-v20.x/docs/api/os.html#oshomedir) was added in `v2.3.0`
- [path.join](https://nodejs.org/dist/latest-v20.x/docs/api/path.html#pathjoinpaths) was added in `v0.1.16`