### PR TITLE
Fix spelling typos across README and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Running doctoc will insert the toc at that location.
 
 ### Specifying a custom TOC title
 
-Use the `--title` option to specify a (Markdown-formatted) custom TOC title; e.g., `doctoc --title '**Contents**' .` From then on, you can simply run `doctoc <file>` and doctoc will will keep the title you specified.
+Use the `--title` option to specify a (Markdown-formatted) custom TOC title; e.g., `doctoc --title '**Contents**' .` From then on, you can simply run `doctoc <file>` and doctoc will keep the title you specified.
 
 Alternatively, to blank out the title, use the `--notitle` option. This will simply remove the title from the TOC.
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -42,7 +42,7 @@ function getMarkdownHeaders (lines, maxHeaderLevel) {
         else if (x.type === md.Syntax.Image) {
           // Images (at least on GitHub, untested elsewhere) are given a hyphen
           // in the slug. We can achieve this behavior by adding an '*' to the
-          // TOC entry. Think of it as a "magic char" that represents the iamge.
+          // TOC entry. Think of it as a "magic char" that represents the image.
           return '*';
         }
         else {

--- a/test/fixtures/readme-with-nested-markdown.md
+++ b/test/fixtures/readme-with-nested-markdown.md
@@ -7,7 +7,7 @@ the link URL.
 
 Chat with the Cockatrice developers on Gitter. Come here to talk about the application, features, or just to hang out. For support regarding specific servers, please contact that server's admin or forum for support rather than asking here.
 
-# Translation Status [![Cockatrice on Transiflex](https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png)](https://www.transifex.com/projects/p/cockatrice/)
+# Translation Status [![Cockatrice on Transifex](https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png)](https://www.transifex.com/projects/p/cockatrice/)
 
 Cockatrice uses Transifex for translations. You can help us bring Cockatrice/Oracle to your language or edit single wordings by clicking on the associated charts below.<br>
 Our [project page](https://www.transifex.com/projects/p/cockatrice/) offers a detailed overview for contributors.

--- a/test/transform.js
+++ b/test/transform.js
@@ -354,7 +354,7 @@ test('transforming when old toc exists and --all flag is set', function (t) {
 })
 
 
-// bigbucket.org
+// bitbucket.org
 check(
     [ '# My Module'
     , 'Some text here'


### PR DESCRIPTION
Fixes misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/doctoc/actions/runs/6512443492#summary-17690088010

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/doctoc/actions/runs/6512443486#summary-17690087990