### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,456 @@
+# Changelog
+
+## [Unreleased](https://github.com/thlorenz/doctoc/tree/HEAD)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v2.2.0...HEAD)
+
+**Closed issues:**
+
+- Smashing on someone, standing on, laying on ect.... [\#230](https://github.com/thlorenz/doctoc/issues/230)
+- Hala [\#228](https://github.com/thlorenz/doctoc/issues/228)
+- Migrate Travis-CI.org to Travis-CI.com / Re-enable CI [\#227](https://github.com/thlorenz/doctoc/issues/227)
+- containerize doctoc [\#221](https://github.com/thlorenz/doctoc/issues/221)
+- TOC Does not generate in a file produced from a powershell script.  [\#210](https://github.com/thlorenz/doctoc/issues/210)
+- TOC headers with emoji create broken relative-links [\#191](https://github.com/thlorenz/doctoc/issues/191)
+- Add a Dockerfile to containerise the tool [\#173](https://github.com/thlorenz/doctoc/issues/173)
+- Plugin for Atom [\#102](https://github.com/thlorenz/doctoc/issues/102)
+
+**Merged pull requests:**
+
+- chore: update node lts versions in node.js.yml workflow [\#236](https://github.com/thlorenz/doctoc/pull/236) ([hongaar](https://github.com/hongaar))
+- fix: formatted headers [\#235](https://github.com/thlorenz/doctoc/pull/235) ([hongaar](https://github.com/hongaar))
+- chore: Update build status badge from Travis-\>Actions [\#233](https://github.com/thlorenz/doctoc/pull/233) ([kevin-david](https://github.com/kevin-david))
+- Upgrade `anchor-markdown-header` to fix emoji-titled headers [\#232](https://github.com/thlorenz/doctoc/pull/232) ([kevin-david](https://github.com/kevin-david))
+- Migrate to Actions for CI [\#231](https://github.com/thlorenz/doctoc/pull/231) ([kevin-david](https://github.com/kevin-david))
+- Add unoficial Docker image info in README.md [\#226](https://github.com/thlorenz/doctoc/pull/226) ([PeterDaveHello](https://github.com/PeterDaveHello))
+
+## [v2.2.0](https://github.com/thlorenz/doctoc/tree/v2.2.0) (2022-05-03)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v2.1.0...v2.2.0)
+
+**Closed issues:**
+
+- please release/tag doctoc with the  \<!-- DOCTOC SKIP --\> feature included  [\#208](https://github.com/thlorenz/doctoc/issues/208)
+
+**Merged pull requests:**
+
+- fix: upgrade deps [\#225](https://github.com/thlorenz/doctoc/pull/225) ([hongaar](https://github.com/hongaar))
+
+## [v2.1.0](https://github.com/thlorenz/doctoc/tree/v2.1.0) (2021-10-13)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v2.0.1...v2.1.0)
+
+**Closed issues:**
+
+- Create title and description before table of contents  [\#214](https://github.com/thlorenz/doctoc/issues/214)
+- Doc [\#204](https://github.com/thlorenz/doctoc/issues/204)
+- Request: Support checking if TOCs are up to date [\#131](https://github.com/thlorenz/doctoc/issues/131)
+
+**Merged pull requests:**
+
+- Bump path-parse from 1.0.6 to 1.0.7 [\#212](https://github.com/thlorenz/doctoc/pull/212) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump glob-parent from 5.1.1 to 5.1.2 [\#207](https://github.com/thlorenz/doctoc/pull/207) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Add unit test for skipping\(Handle file skipping internally \#143\) [\#206](https://github.com/thlorenz/doctoc/pull/206) ([wolfcon](https://github.com/wolfcon))
+- Handle file skipping internally [\#143](https://github.com/thlorenz/doctoc/pull/143) ([zyskowsk](https://github.com/zyskowsk))
+
+## [v2.0.1](https://github.com/thlorenz/doctoc/tree/v2.0.1) (2021-06-07)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v2.0.0...v2.0.1)
+
+**Closed issues:**
+
+- CVE-2021-23358 in underscore dependency [\#199](https://github.com/thlorenz/doctoc/issues/199)
+- Doctoc [\#195](https://github.com/thlorenz/doctoc/issues/195)
+- doctoc pinned to 1.4.0 returns 2.0.0 for version [\#190](https://github.com/thlorenz/doctoc/issues/190)
+- \[Bug?\] `--update-only` option doesn't seem to be recognized as of v1.4.0 [\#189](https://github.com/thlorenz/doctoc/issues/189)
+
+**Merged pull requests:**
+
+- Bump lodash from 4.17.20 to 4.17.21 [\#203](https://github.com/thlorenz/doctoc/pull/203) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump hosted-git-info from 2.8.8 to 2.8.9 [\#202](https://github.com/thlorenz/doctoc/pull/202) ([dependabot[bot]](https://github.com/apps/dependabot))
+- security: CVE-2021-23358 in underscore [\#200](https://github.com/thlorenz/doctoc/pull/200) ([greyscaled](https://github.com/greyscaled))
+- Bump y18n from 4.0.0 to 4.0.1 [\#194](https://github.com/thlorenz/doctoc/pull/194) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v2.0.0](https://github.com/thlorenz/doctoc/tree/v2.0.0) (2020-12-04)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.4.0...v2.0.0)
+
+**Closed issues:**
+
+- Invalid TOC generated [\#166](https://github.com/thlorenz/doctoc/issues/166)
+- Installation via npm gives 404 error [\#162](https://github.com/thlorenz/doctoc/issues/162)
+- markdown-to-ast is deprecated [\#148](https://github.com/thlorenz/doctoc/issues/148)
+- doctoc --notitle creates a superfluous blank line [\#101](https://github.com/thlorenz/doctoc/issues/101)
+
+**Merged pull requests:**
+
+- Bump lodash from 4.17.15 to 4.17.20 [\#187](https://github.com/thlorenz/doctoc/pull/187) ([dependabot[bot]](https://github.com/apps/dependabot))
+- add --all flag [\#186](https://github.com/thlorenz/doctoc/pull/186) ([sarisia](https://github.com/sarisia))
+- feat: add option to keep files with no toc inside untouched [\#181](https://github.com/thlorenz/doctoc/pull/181) ([uetchy](https://github.com/uetchy))
+- Update Travis Build [\#180](https://github.com/thlorenz/doctoc/pull/180) ([edumco](https://github.com/edumco))
+- Update dependencies to fix deprecation warnings [\#179](https://github.com/thlorenz/doctoc/pull/179) ([lydell](https://github.com/lydell))
+- pre-commit docs: update sha -\> rev [\#178](https://github.com/thlorenz/doctoc/pull/178) ([asottile](https://github.com/asottile))
+- expose API in top level [\#160](https://github.com/thlorenz/doctoc/pull/160) ([alexandru-constantin](https://github.com/alexandru-constantin))
+- Collapse consecutive blank lines if there's no title [\#145](https://github.com/thlorenz/doctoc/pull/145) ([chocolateboy](https://github.com/chocolateboy))
+
+## [v1.4.0](https://github.com/thlorenz/doctoc/tree/v1.4.0) (2018-11-21)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.3.1...v1.4.0)
+
+**Closed issues:**
+
+- Use git hooks pre-commit , run ❌ [\#150](https://github.com/thlorenz/doctoc/issues/150)
+- \[bitbucket server\] - no action after click the links [\#144](https://github.com/thlorenz/doctoc/issues/144)
+
+## [v1.3.1](https://github.com/thlorenz/doctoc/tree/v1.3.1) (2018-02-14)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.3.0...v1.3.1)
+
+**Closed issues:**
+
+- "White Heavy Check Mark" [\#139](https://github.com/thlorenz/doctoc/issues/139)
+- Missing items in TOC [\#129](https://github.com/thlorenz/doctoc/issues/129)
+- Some issues slip through in unit tests [\#125](https://github.com/thlorenz/doctoc/issues/125)
+
+**Merged pull requests:**
+
+- Update .travis.yml [\#136](https://github.com/thlorenz/doctoc/pull/136) ([PeterDaveHello](https://github.com/PeterDaveHello))
+- Add pre-commit metadata to doctoc [\#134](https://github.com/thlorenz/doctoc/pull/134) ([asottile](https://github.com/asottile))
+- Update comment [\#133](https://github.com/thlorenz/doctoc/pull/133) ([faheel](https://github.com/faheel))
+
+## [v1.3.0](https://github.com/thlorenz/doctoc/tree/v1.3.0) (2017-02-27)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.2.0...v1.3.0)
+
+**Fixed bugs:**
+
+- Can't regex process \<hX\> when X is an integer [\#36](https://github.com/thlorenz/doctoc/issues/36)
+
+**Closed issues:**
+
+- Would we consider migrating test suite to AVA? [\#124](https://github.com/thlorenz/doctoc/issues/124)
+- Emojis in headings break links [\#123](https://github.com/thlorenz/doctoc/issues/123)
+- Not adding a Heading [\#121](https://github.com/thlorenz/doctoc/issues/121)
+- & Symbol in Headings [\#118](https://github.com/thlorenz/doctoc/issues/118)
+- Create base link for anchors [\#117](https://github.com/thlorenz/doctoc/issues/117)
+- Create title with base in title parameter on jekyll \(github\) markdown file [\#116](https://github.com/thlorenz/doctoc/issues/116)
+- Link in contents doesn’t scroll to content [\#115](https://github.com/thlorenz/doctoc/issues/115)
+- Output to stdout [\#100](https://github.com/thlorenz/doctoc/issues/100)
+
+**Merged pull requests:**
+
+- Bump npm dependencies \(npm test passed!\) [\#126](https://github.com/thlorenz/doctoc/pull/126) ([PeterDaveHello](https://github.com/PeterDaveHello))
+
+## [v1.2.0](https://github.com/thlorenz/doctoc/tree/v1.2.0) (2016-06-17)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.1.1...v1.2.0)
+
+**Fixed bugs:**
+
+- @ in a header [\#104](https://github.com/thlorenz/doctoc/issues/104)
+- Broken Github links when heading has at symbol \(@\) [\#81](https://github.com/thlorenz/doctoc/issues/81)
+
+**Closed issues:**
+
+- Custom marker style [\#108](https://github.com/thlorenz/doctoc/issues/108)
+
+**Merged pull requests:**
+
+- Peg anchor-markdown-header to ^0.5.5 [\#110](https://github.com/thlorenz/doctoc/pull/110) ([jez](https://github.com/jez))
+
+## [v1.1.1](https://github.com/thlorenz/doctoc/tree/v1.1.1) (2016-06-01)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.1.0...v1.1.1)
+
+**Closed issues:**
+
+- Failed to create TOC [\#94](https://github.com/thlorenz/doctoc/issues/94)
+
+**Merged pull requests:**
+
+- Upgrade markdown-to-ast [\#106](https://github.com/thlorenz/doctoc/pull/106) ([jez](https://github.com/jez))
+
+## [v1.1.0](https://github.com/thlorenz/doctoc/tree/v1.1.0) (2016-06-01)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v1.0.0...v1.1.0)
+
+**Fixed bugs:**
+
+- doctoc failing with https://github.com/iogf/untwisted/blob/master/BOOK.md [\#99](https://github.com/thlorenz/doctoc/issues/99)
+- Do not parse code [\#88](https://github.com/thlorenz/doctoc/issues/88)
+- ignore headers within code blocks  [\#84](https://github.com/thlorenz/doctoc/issues/84)
+- skip contents in \<pre\>\</pre\> [\#38](https://github.com/thlorenz/doctoc/issues/38)
+
+**Closed issues:**
+
+- Do not parse horizontal lines [\#95](https://github.com/thlorenz/doctoc/issues/95)
+- Doctoc is ignoring some headers [\#86](https://github.com/thlorenz/doctoc/issues/86)
+- invalid header comment \<-- --\> for bitbucket  [\#83](https://github.com/thlorenz/doctoc/issues/83)
+
+**Merged pull requests:**
+
+- Use markdown + html parsers to detect codeblocks [\#107](https://github.com/thlorenz/doctoc/pull/107) ([jez](https://github.com/jez))
+- change badge to svg [\#103](https://github.com/thlorenz/doctoc/pull/103) ([a0viedo](https://github.com/a0viedo))
+
+## [v1.0.0](https://github.com/thlorenz/doctoc/tree/v1.0.0) (2016-01-29)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.15.0...v1.0.0)
+
+**Closed issues:**
+
+- Clicking on links does not take us to the anchor [\#85](https://github.com/thlorenz/doctoc/issues/85)
+- Hyperlinked heading is linked with heading's hyperlink, not heading anchor [\#69](https://github.com/thlorenz/doctoc/issues/69)
+
+**Merged pull requests:**
+
+- Parse headers as markdown \(bugs fixed\) [\#91](https://github.com/thlorenz/doctoc/pull/91) ([jez](https://github.com/jez))
+
+## [v0.15.0](https://github.com/thlorenz/doctoc/tree/v0.15.0) (2015-08-12)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.14.2...v0.15.0)
+
+**Closed issues:**
+
+- The --github switch does not work for GitHub markdown, --gitlab must be used instead. [\#76](https://github.com/thlorenz/doctoc/issues/76)
+- Use anchor IDs without dashes for headers that include spaces. [\#75](https://github.com/thlorenz/doctoc/issues/75)
+- Github does not support UTF-8 fully [\#74](https://github.com/thlorenz/doctoc/issues/74)
+- TOC creates invalid links when headers have inline images. [\#73](https://github.com/thlorenz/doctoc/issues/73)
+- TOC incorrect link to header that contains vertical bar character [\#71](https://github.com/thlorenz/doctoc/issues/71)
+
+## [v0.14.2](https://github.com/thlorenz/doctoc/tree/v0.14.2) (2015-07-01)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.14.1...v0.14.2)
+
+## [v0.14.1](https://github.com/thlorenz/doctoc/tree/v0.14.1) (2015-06-24)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.14.0...v0.14.1)
+
+**Closed issues:**
+
+- Skip file [\#66](https://github.com/thlorenz/doctoc/issues/66)
+
+## [v0.14.0](https://github.com/thlorenz/doctoc/tree/v0.14.0) (2015-06-12)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.13.0...v0.14.0)
+
+**Closed issues:**
+
+- Infer --title [\#64](https://github.com/thlorenz/doctoc/issues/64)
+- Bug For a header with special characters an invalid link is generated [\#63](https://github.com/thlorenz/doctoc/issues/63)
+- GitLab mode needs 4-spaces indentation [\#61](https://github.com/thlorenz/doctoc/issues/61)
+- Script does not generate anchors. [\#60](https://github.com/thlorenz/doctoc/issues/60)
+- Bug not generating entries for all headers in a file [\#59](https://github.com/thlorenz/doctoc/issues/59)
+- Bug when a heading contains a dollar sign wrapped in code ticks [\#58](https://github.com/thlorenz/doctoc/issues/58)
+
+## [v0.13.0](https://github.com/thlorenz/doctoc/tree/v0.13.0) (2015-04-21)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.12.0...v0.13.0)
+
+**Implemented enhancements:**
+
+- Feature request: max depth [\#44](https://github.com/thlorenz/doctoc/issues/44)
+
+**Closed issues:**
+
+- Doctoc generates incorrect anchor link when there is a url link in the header [\#57](https://github.com/thlorenz/doctoc/issues/57)
+- Doctoc generating newline in header entries [\#56](https://github.com/thlorenz/doctoc/issues/56)
+- Header with & [\#55](https://github.com/thlorenz/doctoc/issues/55)
+- Add way of checking if existing ToCs need updating [\#54](https://github.com/thlorenz/doctoc/issues/54)
+- Overview of all Files/Sections [\#53](https://github.com/thlorenz/doctoc/issues/53)
+- Suggestion: allow passing the TOC title via command-line argument [\#51](https://github.com/thlorenz/doctoc/issues/51)
+- Add GitHub repo URL [\#49](https://github.com/thlorenz/doctoc/issues/49)
+- Soft link causes doctoc to crash. [\#42](https://github.com/thlorenz/doctoc/issues/42)
+
+## [v0.12.0](https://github.com/thlorenz/doctoc/tree/v0.12.0) (2015-02-05)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.11.0...v0.12.0)
+
+**Closed issues:**
+
+- Seems that --nodejs is broken as of v0.11.0 [\#50](https://github.com/thlorenz/doctoc/issues/50)
+
+## [v0.11.0](https://github.com/thlorenz/doctoc/tree/v0.11.0) (2015-01-25)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.10.0...v0.11.0)
+
+**Closed issues:**
+
+- Bitbucket nested links [\#46](https://github.com/thlorenz/doctoc/issues/46)
+
+## [v0.10.0](https://github.com/thlorenz/doctoc/tree/v0.10.0) (2015-01-19)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.9.1...v0.10.0)
+
+**Merged pull requests:**
+
+- Bitbucket mode uses 4 spaces for nested lists. [\#47](https://github.com/thlorenz/doctoc/pull/47) ([plumlee](https://github.com/plumlee))
+
+## [v0.9.1](https://github.com/thlorenz/doctoc/tree/v0.9.1) (2015-01-12)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.9.0...v0.9.1)
+
+## [v0.9.0](https://github.com/thlorenz/doctoc/tree/v0.9.0) (2015-01-12)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.8.0...v0.9.0)
+
+## [v0.8.0](https://github.com/thlorenz/doctoc/tree/v0.8.0) (2015-01-12)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.7.1...v0.8.0)
+
+**Implemented enhancements:**
+
+- Specify level of depth [\#33](https://github.com/thlorenz/doctoc/issues/33)
+
+**Closed issues:**
+
+- http://doctoc.herokuapp.com/ is down... [\#43](https://github.com/thlorenz/doctoc/issues/43)
+- Does this still install as a command line executable? [\#39](https://github.com/thlorenz/doctoc/issues/39)
+- Can [\#35](https://github.com/thlorenz/doctoc/issues/35)
+- Exclamation marks \(!\) in headers break toc links [\#34](https://github.com/thlorenz/doctoc/issues/34)
+- Mixes spaces and tabs [\#32](https://github.com/thlorenz/doctoc/issues/32)
+
+## [v0.7.1](https://github.com/thlorenz/doctoc/tree/v0.7.1) (2014-04-25)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.7.0...v0.7.1)
+
+## [v0.7.0](https://github.com/thlorenz/doctoc/tree/v0.7.0) (2014-04-23)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.6.0...v0.7.0)
+
+## [v0.6.0](https://github.com/thlorenz/doctoc/tree/v0.6.0) (2014-04-23)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.5.3...v0.6.0)
+
+**Closed issues:**
+
+- github markdown will ignore "（" and "）" [\#31](https://github.com/thlorenz/doctoc/issues/31)
+- Special characters in headings should be stripped from anchor names [\#26](https://github.com/thlorenz/doctoc/issues/26)
+- Bad links for titles containing ticks [\#20](https://github.com/thlorenz/doctoc/issues/20)
+
+## [v0.5.3](https://github.com/thlorenz/doctoc/tree/v0.5.3) (2014-03-07)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.5.2...v0.5.3)
+
+**Implemented enhancements:**
+
+- GitLab compatible links [\#27](https://github.com/thlorenz/doctoc/issues/27)
+
+**Closed issues:**
+
+- GitHub wiki rewrites links [\#21](https://github.com/thlorenz/doctoc/issues/21)
+
+## [v0.5.2](https://github.com/thlorenz/doctoc/tree/v0.5.2) (2014-03-07)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.5.1...v0.5.2)
+
+**Implemented enhancements:**
+
+- doctoc generates TOC before Title, unlike sample [\#23](https://github.com/thlorenz/doctoc/issues/23)
+
+## [v0.5.1](https://github.com/thlorenz/doctoc/tree/v0.5.1) (2014-03-07)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.5.0...v0.5.1)
+
+## [v0.5.0](https://github.com/thlorenz/doctoc/tree/v0.5.0) (2014-03-07)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.4.5...v0.5.0)
+
+## [v0.4.5](https://github.com/thlorenz/doctoc/tree/v0.4.5) (2014-03-05)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.4.4...v0.4.5)
+
+**Closed issues:**
+
+- TOC entries which have single quote and semicolon in them do not link properly. [\#28](https://github.com/thlorenz/doctoc/issues/28)
+
+**Merged pull requests:**
+
+- return the toc [\#29](https://github.com/thlorenz/doctoc/pull/29) ([Raynos](https://github.com/Raynos))
+
+## [v0.4.4](https://github.com/thlorenz/doctoc/tree/v0.4.4) (2013-12-15)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.4.3...v0.4.4)
+
+**Closed issues:**
+
+- Doesn't capture all headings in this file [\#24](https://github.com/thlorenz/doctoc/issues/24)
+- DocToc gets confused by dashes in pargraphs [\#18](https://github.com/thlorenz/doctoc/issues/18)
+
+**Merged pull requests:**
+
+- Add a Bitdeli Badge to README [\#25](https://github.com/thlorenz/doctoc/pull/25) ([bitdeli-chef](https://github.com/bitdeli-chef))
+
+## [v0.4.3](https://github.com/thlorenz/doctoc/tree/v0.4.3) (2013-08-10)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.4.2...v0.4.3)
+
+**Closed issues:**
+
+- DocToc discards text without headers [\#19](https://github.com/thlorenz/doctoc/issues/19)
+
+## [v0.4.2](https://github.com/thlorenz/doctoc/tree/v0.4.2) (2013-05-01)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.4.1...v0.4.2)
+
+**Closed issues:**
+
+- add support for github wiki pages [\#12](https://github.com/thlorenz/doctoc/issues/12)
+- Add support for Bitbucket markdown [\#11](https://github.com/thlorenz/doctoc/issues/11)
+
+## [v0.4.1](https://github.com/thlorenz/doctoc/tree/v0.4.1) (2013-04-10)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.4.0...v0.4.1)
+
+**Merged pull requests:**
+
+- Sort the headers before making ToC. [\#14](https://github.com/thlorenz/doctoc/pull/14) ([qubyte](https://github.com/qubyte))
+
+## [v0.4.0](https://github.com/thlorenz/doctoc/tree/v0.4.0) (2013-04-10)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.3.0...v0.4.0)
+
+## [v0.3.0](https://github.com/thlorenz/doctoc/tree/v0.3.0) (2013-04-01)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.2.1...v0.3.0)
+
+## [v0.2.1](https://github.com/thlorenz/doctoc/tree/v0.2.1) (2013-02-26)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.2.0...v0.2.1)
+
+**Implemented enhancements:**
+
+- Handle double \# style headings [\#6](https://github.com/thlorenz/doctoc/issues/6)
+
+**Fixed bugs:**
+
+- Related issue raised in doctoc-web [\#8](https://github.com/thlorenz/doctoc/issues/8)
+
+**Merged pull requests:**
+
+- Ignore hash-based comments inside code blocks [\#10](https://github.com/thlorenz/doctoc/pull/10) ([miangraham-ss](https://github.com/miangraham-ss))
+
+## [v0.2.0](https://github.com/thlorenz/doctoc/tree/v0.2.0) (2013-02-09)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.1.0...v0.2.0)
+
+**Implemented enhancements:**
+
+- ability to run on a single file [\#7](https://github.com/thlorenz/doctoc/issues/7)
+
+## [v0.1.0](https://github.com/thlorenz/doctoc/tree/v0.1.0) (2013-02-07)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/v0.0.3...v0.1.0)
+
+**Closed issues:**
+
+- Generate anchors [\#5](https://github.com/thlorenz/doctoc/issues/5)
+- Header look-a-likes within "fenced code blocks" detected as headers [\#4](https://github.com/thlorenz/doctoc/issues/4)
+- `npm install -g doctoc`-\> "No compatible version found" [\#1](https://github.com/thlorenz/doctoc/issues/1)
+
+## [v0.0.3](https://github.com/thlorenz/doctoc/tree/v0.0.3) (2012-08-12)
+
+[Full Changelog](https://github.com/thlorenz/doctoc/compare/23ecccb0a50a1b1e368877e33d0e66d25e2e63f1...v0.0.3)
+
+**Closed issues:**
+
+- doctoc.herokuapp.com generates nothing for github wiki markdown [\#2](https://github.com/thlorenz/doctoc/issues/2)


### PR DESCRIPTION
Uses [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) to generate changelog. It has been almost 3 years since that issue and it hasn't been tackled - meanwhile, newer users (like myself) have not been able to have the CHANGELOG experience.

Closes #197