### PR TITLE
feat: add mdx support

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -16,7 +16,7 @@ function cleanPath(path) {
   return homeExpanded.replace(/\s/g, '\\ ');
 }
 
-function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly) {
+function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax) {
   if (processAll) {
     console.log('--all flag is enabled. Including headers before the TOC location.')
   }
@@ -24,13 +24,13 @@ function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPref
   if (updateOnly) {
     console.log('--update-only flag is enabled. Only updating files that already have a TOC.')
   }
-  
+
   console.log('\n==================\n');
 
   var transformed = files
     .map(function (x) {
       var content = fs.readFileSync(x.path, 'utf8')
-        , result = transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, updateOnly);
+        , result = transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, updateOnly, syntax);
       result.path = x.path;
       return result;
     });
@@ -48,7 +48,7 @@ function transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPref
     console.log('"%s" is up to date', x.path);
   });
 
-  changed.forEach(function (x) { 
+  changed.forEach(function (x) {
     if (stdOut) {
       console.log('==================\n\n"%s" should be updated', x.path)
     } else {
@@ -62,7 +62,7 @@ function printUsageAndExit(isErr) {
 
   var outputFunc = isErr ? console.error : console.info;
 
-  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--all] [--update-only] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
+  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--all] [--update-only] [--syntax (md|mdx)] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
   outputFunc('\nAvailable modes are:');
   for (var key in modes) {
     outputFunc('  --%s\t%s', key, modes[key]);
@@ -84,7 +84,7 @@ var mode = modes['github'];
 
 var argv = minimist(process.argv.slice(2)
     , { boolean: [ 'h', 'help', 'T', 'notitle', 's', 'stdout', 'all' , 'u', 'update-only'].concat(Object.keys(modes))
-    , string: [ 'title', 't', 'maxlevel', 'm', 'entryprefix' ]
+    , string: [ 'title', 't', 'maxlevel', 'm', 'entryprefix', 'syntax' ]
     , unknown: function(a) { return (a[0] == '-' ? (console.error('Unknown option(s): ' + a), printUsageAndExit(true)) : true); }
     });
 
@@ -104,7 +104,7 @@ var entryPrefix = argv.entryprefix || '-';
 var processAll = argv.all;
 var stdOut = argv.s || argv.stdout
 var updateOnly = argv.u || argv['update-only']
-
+var syntax = argv['syntax'] || "md"
 var maxHeaderLevel = argv.m || argv.maxlevel;
 if (maxHeaderLevel && isNaN(maxHeaderLevel) || maxHeaderLevel < 0) { console.error('Max. heading level specified is not a positive number: ' + maxHeaderLevel), printUsageAndExit(true); }
 
@@ -120,7 +120,7 @@ for (var i = 0; i < argv._.length; i++) {
     files = [{ path: target }];
   }
 
-  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly);
+  transformAndSave(files, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax);
 
   console.log('\nEverything is OK.');
 }

--- a/lib/file.js
+++ b/lib/file.js
@@ -2,7 +2,7 @@ var path  =  require('path')
  ,  fs  =  require('fs')
  ,  _   =  require('underscore');
 
-var markdownExts = ['.md', '.markdown'];
+var markdownExts = ['.md', '.markdown', '.mdx'];
 var ignoredDirs  = ['.', '..', '.git', 'node_modules'];
 
 function separateFilesAndDirs(fileInfos) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -6,18 +6,29 @@ var _             = require('underscore')
   , getHtmlHeaders = require('./get-html-headers')
   , md            = require('@textlint/markdown-to-ast');
 
-var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
-            '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'
-  , end   = '<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
-  , skipTag = '<!-- DOCTOC SKIP -->';
+var commentTypes = {
+  md: {
+    start: "<!--",
+    end: "-->",
+    escapedStart: "<!--",
+  },
+  mdx: {
+    start: "{/*",
+    end: "*/}",
+    escapedStart: "{\/\\*",
+  }
+}
 
+var { start: startMd , end: endMd } = generateComments("md")
+
+var commentEscapedStart = commentTypes.md.escapedStart
 
 function matchesStart(line) {
-  return (/<!-- START doctoc /).test(line);
+  return new RegExp(`${commentEscapedStart} START doctoc `).test(line);
 }
 
 function matchesEnd(line) {
-  return (/<!-- END doctoc /).test(line);
+  return new RegExp(`${commentEscapedStart} END doctoc `).test(line);
 }
 
 function notNull(x) { return  x !== null; }
@@ -31,6 +42,17 @@ function isString(y) {
   return typeof y === 'string';
 }
 
+function generateComments(syntax){
+  var commentStart = commentTypes[syntax]?.start || commentTypes.md.start
+  , commentEnd = commentTypes[syntax]?.end || commentTypes.md.end
+
+  var start = `${commentStart} START doctoc generated TOC please keep comment here to allow auto update ${commentEnd}\n` +
+            `${commentStart} DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE ${commentEnd}`
+  , end   = `${commentStart} END doctoc generated TOC please keep comment here to allow auto update ${commentEnd}`
+  , skipTag = `${commentStart} DOCTOC SKIP ${commentEnd}`;
+
+  return { start, end, skipTag}
+}
 
 function getMarkdownHeaders (lines, maxHeaderLevel) {
   function extractText (header) {
@@ -108,11 +130,17 @@ function determineTitle(title, notitle, lines, info) {
   return info.hasStart ? lines[info.startIdx + 2] : defaultTitle;
 }
 
-exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, updateOnly) {
+exports = module.exports = function transform(content, mode, maxHeaderLevel, title, notitle, entryPrefix, processAll, updateOnly, syntax) {
+  syntax = syntax || "md"
+  const { skipTag, start, end } = generateComments(syntax)
+
   if (content.indexOf(skipTag) !== -1) return { transformed: false };
 
   mode = mode || 'github.com';
   entryPrefix = entryPrefix || '-';
+
+  // update it for matchesStart and matchesEnd
+  commentEscapedStart = commentTypes[syntax]?.escapedStart || commentTypes.md.escapedStart
 
   // only limit *HTML* headings by default
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
@@ -168,5 +196,5 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, tit
   return { transformed : true, data : data, toc: toc, wrappedToc: wrappedToc };
 };
 
-exports.start = start;
-exports.end = end;
+exports.start = startMd;
+exports.end = endMd;


### PR DESCRIPTION
closes #211

[This line](https://github.com/thlorenz/doctoc/compare/master...I-3B:mdx-support?expand=1#diff-387904f6b07263914bc1b0cb291a27832cc6963e01b5d44b75460771fc25ee8fR5) may causes problem if some users where only using doctoc for `.md` files, I didn't  check for it, should I?
