### PR TITLE
ci: Address CI Issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-config borrowed from: https://docs.npmjs.com/trusted-publishers#github-actions-configuration
+# config borrowed from: https://docs.npmjs.com/trusted-publishers#github-actions-configuration
 name: Release package
 
 on:


### PR DESCRIPTION
This resolves the ci issues:

- issue not created on publish failure. This locally is now only getting an auth issue which is due to testing on a fork
- publish to npm failed. Likely due to using old version of npm which lacks tpm support.