### PR TITLE
fix: Rename path parameter to avoid shadowing path module

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -10,7 +10,7 @@ var path = require("path"),
   files;
 
 function cleanPath(filePath) {
-  var homeExpanded = (filePpath.indexOf('~') === 0) ? process.env.HOME + filePath.substr(1) : filePath;
+  var homeExpanded = (filePath.indexOf('~') === 0) ? process.env.HOME + filePath.substr(1) : filePath;
 
   return homeExpanded;
 }


### PR DESCRIPTION
The path parameter in the cleanPath function was shadowing the path module imported at the top of the file. This blocks calling path.join(), as currently it is mistakenly treating path as a string method. Renaming the parameter to filepath resolves this issue and improves code clarity.

This is the precursor to #249