### PR TITLE
fix: Improve cleanPath os compatability

### DIFF
--- a/doctoc.js
+++ b/doctoc.js
@@ -4,7 +4,7 @@
 
 var path = require("path"),
   fs = require("fs"),
-  os = require('os'),
+  os = require("os"),
   minimist = require("minimist"),
   file = require("./lib/file"),
   transform = require("./lib/transform"),


### PR DESCRIPTION
This resolves the merge conflicts in #249 and will allow that to be closed. Feedback from that pr has been implemented hence #319 which is to be merged first and enable this to be ready.


Uses os.homedir() since that works better on non-POSIXy platforms.

I know this code uses old conventions and methods, so if NodeJS version compatability is a concern (even though they have been unsupported for decades), these are when these functions were added to NodeJS:

- [os.homedir](https://nodejs.org/dist/latest-v20.x/docs/api/os.html#oshomedir) was added in v2.3.0
- [path.join](https://nodejs.org/dist/latest-v20.x/docs/api/path.html#pathjoinpaths) was added in v0.1.16

Closes: #249