### PR TITLE
chore: Reduce conversion processes

### DIFF
--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -7,11 +7,10 @@ function addLinenos(lines, headers) {
   var current = 0, line;
 
   return headers.map(function (x) {
-    for (var lineno = current; lineno < lines.length; lineno++) {
-      line = lines[lineno];
-      if (new RegExp(x.text[0]).test(line)) {
-        current = lineno;
-        x.line = lineno;
+    for (var lineno = current; lineno < lines.children.length; lineno++) {
+      line = lines.children[lineno];
+      if (new RegExp(x.text[0]).test(line.raw)) {
+        x.line = line.loc.start.line;
         x.name = x.text.join("");
         return x;
       }
@@ -25,11 +24,10 @@ function addLinenos(lines, headers) {
   });
 }
 
-var go = (module.exports = function (lines, maxHeaderLevel, minHeaderLevel) {
-  var source = md
-    .parse(lines.join("\n"))
+var go = (module.exports = function (nodes, start, maxHeaderLevel, minHeaderLevel) {
+  var source = nodes
     .children.filter(function (node) {
-      return node.type === md.Syntax.HtmlBlock || node.type === md.Syntax.Html;
+      return (node.type === md.Syntax.HtmlBlock || node.type === md.Syntax.Html) && node.range[1] > start;
     })
     .map(function (node) {
       return node.raw;
@@ -85,7 +83,7 @@ var go = (module.exports = function (lines, maxHeaderLevel, minHeaderLevel) {
   parser.write(source);
   parser.end();
 
-  headers = addLinenos(lines, headers);
+  headers = addLinenos(nodes, headers);
   // consider anything past h4 to small to warrant a link, may be made configurable in the future
   headers = headers.filter(function (x) {
     return x.rank <= maxHeaderLevel && x.rank >= minHeaderLevel;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -59,7 +59,7 @@ function getTocMarkers(docNodes, pragmaStyle, syntax) {
     position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
     position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
   }
-  else if (pragmaStyle == "legacy" && position?.existing) {
+  else if ((pragmaStyle == "legacy" || !pragmaStyle) && position?.existing) {
     position.start.raw = marker.start;
   }
   return { marker: marker, positions: [position] };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -167,11 +167,11 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   var tocs = getTocMarkers(docNodes, options?.toc?.pragma?.style, syntax);
 
   
-  if (!(tocs?.positions.length > 0) && updateOnly) {
+  if (!(tocs.positions?.length > 0) && updateOnly) {
     return { transformed: false };
   }
   
-  if (!(tocs?.positions.length > 0)) {
+  if (!(tocs.positions?.length > 0)) {
     var insertPos = 0;
     tocs.positions = [{
       end: {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -237,7 +237,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   var transformed = !tocPosition?.existing || content.slice(tocPosition.start.range[0], tocPosition.end.range[1]) != wrappedToc;
   
   if (transformed) {
-    if (tocPosition.start.range[0] > 0) { data.push(content.slice(0, tocPosition.start.range[0])); }
+    if (tocPosition.start.range[0] > 0) { data.push(content.slice(0, tocPosition.start.range[0] - 1)); }
     data.push(wrappedToc);
     if (!tocPosition.existing) { data.push(''); }
     data.push(content.slice(tocPosition.end.range[1] + (tocPosition.existing ? 1 : 0)));

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -25,7 +25,7 @@ function isString(y) {
   return typeof y === 'string';
 }
 
-function getTocs(docNodes, pragmaStyle, syntax) {
+function getTocMarkers(docNodes, pragmaStyle, syntax) {
   var matchesStartBySyntax = matchesStart(syntax);
   var matchesEndBySyntax = matchesEnd(syntax);
   var nodes = docNodes.children.filter(function (x) {
@@ -44,16 +44,18 @@ function getTocs(docNodes, pragmaStyle, syntax) {
     })
     .filter(notNull);
 
-  var original = nodes.length < 2 ? null : {
+  // This finds the position of the existing toc markers
+  var position = nodes.length < 2 ? null : {
     start: nodes.find(n => n.type === "start")?.node,
     end: nodes.find(n => n.type === "end")?.node,
+    existing: start && end,
   };
-  var expected = pragmaStyle == "compact" && original?.start ? {
-    start: original.start.raw.replace(" generated TOC please keep comment here to allow auto update", ""),
-    end: original.end.raw.replace(" generated TOC please keep comment here to allow auto update", ""),
-  } : contentGenerator.pragmaMarkers(syntax, pragmaStyle);
+  if (pragmaStyle == "compact" && usage?.existing) {
+    position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
+    position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
+  }
 
-  return { expected: expected, orignals: original };
+  return { marker: contentGenerator.pragmaMarkers(syntax, pragmaStyle), positions: position };
 }
 
 function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel) {
@@ -117,20 +119,20 @@ function processHeaders(headers, mode) {
 }
 
 // Use document context as well as command line args to infer the title
-function determineTitle(nodes, toc, title, notitle, syntax) {
+function determineTitle(nodes, tocPosition, title, notitle, syntax) {
   var defaultTitle = '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*';
 
   if (notitle) return "";
   if (title) return title;
-  if (!toc.orignals?.start) return defaultTitle;
+  if (!tocPosition?.existing) return defaultTitle;
 
   var listStartIdx = nodes.children.filter(function (x) { 
-    return x.type === md.Syntax.List && x.range[0] > toc.orignals.start.range[0] && x.range[1] < toc.orignals.end.range[1];
+    return x.type === md.Syntax.List && x.range[0] > tocPosition.start.range[0] && x.range[1] < tocPosition.end.range[1];
   })
   .map(function (x) { return x.range[0]; })?.[0];
 
   var paragraphs = nodes.children.filter(function (x) {
-    return x.range[0] > toc.orignals.start.range[0] && x.range[1] < listStartIdx;
+    return x.range[0] > tocPosition.start.range[0] && x.range[1] < listStartIdx;
   });
   return paragraphs?.[paragraphs.length - 1]?.raw;
 }
@@ -158,13 +160,29 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
 
   var docNodes = md.parse(content);
-  var tocs = getTocs(docNodes, options?.toc?.pragma?.style, syntax);
+  var tocs = getTocMarkers(docNodes, options?.toc?.pragma?.style, syntax);
 
-  if (!tocs?.orignals && updateOnly) {
+  if (!tocs.positions && updateOnly) {
     return { transformed: false };
   }
+  
+  if (!tocs?.positions) {
+    var insertPos = 0;
+    tocs.positions = {
+      end: {
+        range: [insertPos, insertPos],
+        raw: tocs.marker.end,
+      },
+      start: {
+        range: [insertPos, insertPos],
+        raw: tocs.marker.start,
+      },
+      existing: false
+    };
+  }
 
-  var tocableStart = !processAll && tocs?.orignals?.start && tocs?.orignals?.end ? tocs.orignals.end.range[1] + 1 : 0;
+  var tocPosition = tocs?.positions;
+  var tocableStart = !processAll ? tocPosition.end.range[1] : 0;
   var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel)
     .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel));
 
@@ -176,7 +194,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
       toc = options.toc.header.content + '\n';
     }
 
-    var inferredTitle = determineTitle(docNodes, tocs, title, notitle, syntax);
+    var inferredTitle = determineTitle(docNodes, tocPosition, title, notitle, syntax);
     
     var allHeaders = processHeaders(headers, mode);
     var lowestRank = allHeaders.reduce((min, h) => Math.min(min, h.rank), Infinity);
@@ -207,15 +225,15 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   }
 
   var data;
-  var wrappedToc = tocs.expected.start + '\n' + (toc != '' ? toc + '\n' : '') + tocs.expected.end;
-  var transformed = !tocs?.orignals?.start || content.slice(tocs.orignals.start.range[0], tocs.orignals.end.range[1]) != wrappedToc;
-  if (!tocs?.orignals?.start) {
+  var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n' : '') + tocPosition.end.raw;
+  var transformed = !tocPosition?.existing || content.slice(tocPosition.start.range[0], tocPosition.end.range[1]) != wrappedToc;
+  if (!tocPosition.existing) {
     data = wrappedToc + '\n\n' + content;
   }
   else if (transformed){
-    data = content.slice(0, tocs.orignals.start.range[0]) +
+    data = content.slice(0, tocPosition.start.range[0]) +
       wrappedToc + '\n' + 
-      content.slice(tocs.orignals.end.range[1] + 1);
+      content.slice(tocPosition.end.range[1] + 1);
   }
   return { transformed : transformed, data : data, toc: toc, wrappedToc: wrappedToc };
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -204,14 +204,10 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (options?.toc?.footer?.content) {
       toc = toc + '\n' + options.toc.footer.content;
     }
-    
-    wrappedToc = tocs.expected.start + '\n' + toc + '\n' + tocs.expected.end;
-  }
-  else {
-    wrappedToc =  tocs.expected.start + '\n' + tocs.expected.end;
   }
 
   var data;
+  var wrappedToc = tocs.expected.start + '\n' + (toc != '' ? toc + '\n' : '') + tocs.expected.end;
   var transformed = !tocs?.orignals?.start || content.slice(tocs.orignals.start.range[0], tocs.orignals.end.range[1]) != wrappedToc;
   if (!tocs?.orignals?.start) {
     data = wrappedToc + '\n\n' + content;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -50,7 +50,7 @@ function getTocMarkers(docNodes, pragmaStyle, syntax) {
     end: nodes.find(n => n.type === "end")?.node,
   };
   if (position) { position.existing = position.start && position.end; }
-  if (pragmaStyle == "compact" && usage?.existing) {
+  if (pragmaStyle == "compact" && position?.existing) {
     position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
     position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
   }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var anchor = require("anchor-markdown-header"),
-  updateSection = require("update-section"),
   getHtmlHeaders = require("./get-html-headers"),
   contentGenerator = require("./content-generation"),
   md = require("@textlint/markdown-to-ast");
@@ -26,25 +25,39 @@ function isString(y) {
   return typeof y === 'string';
 }
 
-function generateMarkers(lines, info, pragmaStyle, syntax){
-  var start, end, header;
+function getTocs(docNodes, pragmaStyle, syntax) {
+  var matchesStartBySyntax = matchesStart(syntax);
+  var matchesEndBySyntax = matchesEnd(syntax);
+  var nodes = docNodes.children.filter(function (x) {
+      return (x.type === md.Syntax.Html && syntax === "md") || (x.type === md.Syntax.Paragraph && syntax === "mdx");
+    })
+    .map(function (x) {
+      if(matchesStartBySyntax(x.raw)){
+        return { type: "start", node: x };
+      }
+      else if(matchesEndBySyntax(x.raw)){
+        return { type: "end", node: x };
+      }
+      else {
+        return null;
+      }
+    })
+    .filter(notNull);
 
-  if (pragmaStyle == "compact" && info.hasStart) {
-    start = lines[info.startIdx];
-    start = start.replace(" generated TOC please keep comment here to allow auto update", "");
-    end = lines[info.endIdx];
-    end = end.replace(" generated TOC please keep comment here to allow auto update", "");
-  }
-  else {
-    var marker = contentGenerator.pragmaMarkers(syntax, pragmaStyle);
-    start = marker.start;
-    end = marker.end;
-  }
+  var original = nodes.length < 2 ? null : {
+    start: nodes.find(n => n.type === "start")?.node,
+    end: nodes.find(n => n.type === "end")?.node,
+  };
+  var defaultPragma = contentGenerator.pragmaMarkers(syntax, pragmaStyle);
+  var expected = pragmaStyle == "compact" && original?.start ? {
+    start: defaultPragma.start.replace(" generated TOC please keep comment here to allow auto update", ""),
+    end: defaultPragma.end.replace(" generated TOC please keep comment here to allow auto update", ""),
+  } : defaultPragma;
 
-  return { start, end };
+  return { expected: expected, orignals: original };
 }
 
-function getMarkdownHeaders (lines, maxHeaderLevel, minHeaderLevel) {
+function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel) {
   function extractText (header) {
     return header.children
       .map(function (x) {
@@ -64,10 +77,9 @@ function getMarkdownHeaders (lines, maxHeaderLevel, minHeaderLevel) {
       .join("");
   }
 
-  return md
-    .parse(lines.join("\n"))
+  return lines
     .children.filter(function (x) {
-      return x.type === md.Syntax.Header;
+      return x.type === md.Syntax.Header && x.range[1] > start;
     })
     .map(function (x) {
       return x.depth >= minHeaderLevel && (!maxHeaderLevel || x.depth <= maxHeaderLevel)
@@ -106,22 +118,27 @@ function processHeaders(headers, mode) {
 }
 
 // Use document context as well as command line args to infer the title
-function determineTitle(title, notitle, lines, info) {
+function determineTitle(nodes, toc, title, notitle, syntax) {
   var defaultTitle = '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*';
 
   if (notitle) return "";
   if (title) return title;
-  if (!info.hasStart) return defaultTitle;
-  var readTitle = lines[info.startIdx + 2];
-  var previousLine = lines[info.startIdx + 1];
-  return readTitle != "" || previousLine.includes("END doctoc") ? readTitle : previousLine;
+  if (!toc.orignals?.start) return defaultTitle;
+
+  var listStartIdx = nodes.children.filter(function (x) { 
+    return x.type === md.Syntax.List && x.range[0] > toc.orignals.start.range[0] && x.range[1] < toc.orignals.end.range[1];
+  })
+  .map(function (x) { return x.range[0]; })?.[0];
+
+  var paragraphs = nodes.children.filter(function (x) {
+    return x.range[0] > toc.orignals.start.range[0] && x.range[1] < listStartIdx;
+  });
+  return paragraphs?.[paragraphs.length - 1]?.raw;
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
   var skipTag = contentGenerator.skipTag(syntax) + '\n';
-  var matchesStartBySyntax = matchesStart(syntax);
-  var matchesEndBySyntax = matchesEnd(syntax);
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === '\n')) return { transformed: false };
 
@@ -141,28 +158,26 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   // only limit *HTML* headings by default
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
 
-  var lines = content.split('\n'),
-    info = updateSection.parse(lines, matchesStartBySyntax, matchesEndBySyntax);
+  var docNodes = md.parse(content);
+  var tocs = getTocs(docNodes, options?.toc?.pragma?.style, syntax);
 
-  if (!info.hasStart && updateOnly) {
+  if (!tocs?.orignals && updateOnly) {
     return { transformed: false };
   }
 
-  var { start, end } = generateMarkers(lines, info, options?.toc?.pragma?.style, syntax);
-  var tocableStart = !processAll && info.hasStart && info.hasEnd ? info.endIdx + 1 : 0;
-  var linesToToc = tocableStart > 0 ? lines.slice(tocableStart) : lines;
-  var headers = getMarkdownHeaders(linesToToc, maxHeaderLevel, minHeaderLevel)
-    .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml, minHeaderLevel));
+  var tocableStart = !processAll && tocs?.orignals?.start && tocs?.orignals?.end ? tocs.orignals.end.range[1] + 1 : 0;
+  var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel)
+    .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel));
 
   var toc = '';
   var wrappedToc;
 
   if (headers.length >= minTocItems) {
     if (options?.toc?.header?.content) {
-      start = start + '\n' + options.toc.header.content;
+      toc = options.toc.header.content + '\n';
     }
 
-    var inferredTitle = determineTitle(title, notitle, lines, info);
+    var inferredTitle = determineTitle(docNodes, tocs, title, notitle, syntax);
     
     var allHeaders = processHeaders(headers, mode);
     var lowestRank = allHeaders.reduce((min, h) => Math.min(min, h.rank), Infinity);
@@ -176,7 +191,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     }
     
     if (inferredTitle) {
-      toc = (padTitle ? '\n' : '') + inferredTitle + '\n';
+      toc = toc + (padTitle ? '\n' : '') + inferredTitle + '\n';
     }
 
     toc = toc + '\n'
@@ -188,27 +203,24 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     + '\n';
     
     if (options?.toc?.footer?.content) {
-      end = options.toc.footer.content + '\n' + end;
+      toc = toc + '\n' + options.toc.footer.content;
     }
     
-    wrappedToc = start + '\n' + toc + '\n' + end;
+    wrappedToc = tocs.expected.start + '\n' + toc + '\n' + tocs.expected.end;
   }
   else {
-    wrappedToc =  start + '\n' + end;
+    wrappedToc =  tocs.expected.start + '\n' + tocs.expected.end;
   }
 
   var data;
-  var transformed = !info.hasStart || lines.slice(info.startIdx, info.endIdx + 1).join('\n') != wrappedToc;
-  if (!info.hasStart) {
+  var transformed = !tocs?.orignals?.start || content.slice(tocs.orignals.start.range[0], tocs.orignals.end.range[1]) != wrappedToc;
+  if (!tocs?.orignals?.start) {
     data = wrappedToc + '\n\n' + content;
   }
   else if (transformed){
-    var sectionLines = wrappedToc.split('\n'),
-      dropN = info.endIdx - info.startIdx + 1;
-
-    [].splice.apply(lines, [ info.startIdx, dropN ].concat(sectionLines));
-
-    data = lines.join('\n');
+    data = content.slice(0, tocs.orignals.start.range[0]) +
+      wrappedToc + '\n' + 
+      content.slice(tocs.orignals.end.range[1] + 1);
   }
   return { transformed : transformed, data : data, toc: toc, wrappedToc: wrappedToc };
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -48,11 +48,10 @@ function getTocs(docNodes, pragmaStyle, syntax) {
     start: nodes.find(n => n.type === "start")?.node,
     end: nodes.find(n => n.type === "end")?.node,
   };
-  var defaultPragma = contentGenerator.pragmaMarkers(syntax, pragmaStyle);
   var expected = pragmaStyle == "compact" && original?.start ? {
-    start: defaultPragma.start.replace(" generated TOC please keep comment here to allow auto update", ""),
-    end: defaultPragma.end.replace(" generated TOC please keep comment here to allow auto update", ""),
-  } : defaultPragma;
+    start: original.start.replace(" generated TOC please keep comment here to allow auto update", ""),
+    end: original.end.replace(" generated TOC please keep comment here to allow auto update", ""),
+  } : contentGenerator.pragmaMarkers(syntax, pragmaStyle);
 
   return { expected: expected, orignals: original };
 }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -44,7 +44,7 @@ function getTocMarkers(docNodes, pragmaStyle, syntax) {
     })
     .filter(notNull);
 
-  var marker = marker: contentGenerator.pragmaMarkers(syntax, pragmaStyle);
+  var marker = contentGenerator.pragmaMarkers(syntax, pragmaStyle);
   
   // This finds the position of the existing toc markers
   var position = nodes.length < 2 ? null : {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -49,8 +49,8 @@ function getTocs(docNodes, pragmaStyle, syntax) {
     end: nodes.find(n => n.type === "end")?.node,
   };
   var expected = pragmaStyle == "compact" && original?.start ? {
-    start: original.start.replace(" generated TOC please keep comment here to allow auto update", ""),
-    end: original.end.replace(" generated TOC please keep comment here to allow auto update", ""),
+    start: original.start.raw.replace(" generated TOC please keep comment here to allow auto update", ""),
+    end: original.end.raw.replace(" generated TOC please keep comment here to allow auto update", ""),
   } : contentGenerator.pragmaMarkers(syntax, pragmaStyle);
 
   return { expected: expected, orignals: original };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -48,14 +48,14 @@ function getTocMarkers(docNodes, pragmaStyle, syntax) {
   var position = nodes.length < 2 ? null : {
     start: nodes.find(n => n.type === "start")?.node,
     end: nodes.find(n => n.type === "end")?.node,
-    existing: start && end,
   };
+  if (position) { position.existing = position.start && position.end; }
   if (pragmaStyle == "compact" && usage?.existing) {
     position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
     position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
   }
-
-  return { marker: contentGenerator.pragmaMarkers(syntax, pragmaStyle), positions: position };
+  var positions = [position];
+  return { marker: contentGenerator.pragmaMarkers(syntax, pragmaStyle), positions: positions };
 }
 
 function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel) {
@@ -162,13 +162,14 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   var docNodes = md.parse(content);
   var tocs = getTocMarkers(docNodes, options?.toc?.pragma?.style, syntax);
 
-  if (!tocs.positions && updateOnly) {
+  
+  if (!tocs?.positions && updateOnly) {
     return { transformed: false };
   }
   
   if (!tocs?.positions) {
     var insertPos = 0;
-    tocs.positions = {
+    tocs.positions = [{
       end: {
         range: [insertPos, insertPos],
         raw: tocs.marker.end,
@@ -178,10 +179,10 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
         raw: tocs.marker.start,
       },
       existing: false
-    };
+    }];
   }
 
-  var tocPosition = tocs?.positions;
+  var tocPosition = tocs?.positions[0];
   var tocableStart = !processAll ? tocPosition.end.range[1] : 0;
   var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel)
     .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel));

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -59,6 +59,9 @@ function getTocMarkers(docNodes, pragmaStyle, syntax) {
     position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
     position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
   }
+  else if (pragmaStyle == "legacy" && position?.existing) {
+    position.start.raw = marker.start;
+  }
   return { marker: marker, positions: [position] };
 }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -44,18 +44,22 @@ function getTocMarkers(docNodes, pragmaStyle, syntax) {
     })
     .filter(notNull);
 
+  var marker = marker: contentGenerator.pragmaMarkers(syntax, pragmaStyle);
+  
   // This finds the position of the existing toc markers
   var position = nodes.length < 2 ? null : {
     start: nodes.find(n => n.type === "start")?.node,
     end: nodes.find(n => n.type === "end")?.node,
   };
-  if (position) { position.existing = position.start && position.end; }
+  if (!position) {
+    return { marker: marker };
+  }
+  position.existing = position.start && position.end;
   if (pragmaStyle == "compact" && position?.existing) {
     position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
     position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
   }
-  var positions = [position];
-  return { marker: contentGenerator.pragmaMarkers(syntax, pragmaStyle), positions: positions };
+  return { marker: marker, positions: [position] };
 }
 
 function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel) {
@@ -163,11 +167,11 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   var tocs = getTocMarkers(docNodes, options?.toc?.pragma?.style, syntax);
 
   
-  if (!tocs?.positions && updateOnly) {
+  if (!(tocs?.positions.length > 0) && updateOnly) {
     return { transformed: false };
   }
   
-  if (!tocs?.positions) {
+  if (!(tocs?.positions.length > 0)) {
     var insertPos = 0;
     tocs.positions = [{
       end: {
@@ -182,7 +186,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     }];
   }
 
-  var tocPosition = tocs?.positions[0];
+  var tocPosition = tocs.positions[0];
   var tocableStart = !processAll ? tocPosition.end.range[1] : 0;
   var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel)
     .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel));

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -232,16 +232,15 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     }
   }
 
-  var data;
+  var data = [];
   var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n' : '') + tocPosition.end.raw;
   var transformed = !tocPosition?.existing || content.slice(tocPosition.start.range[0], tocPosition.end.range[1]) != wrappedToc;
-  if (!tocPosition.existing) {
-    data = wrappedToc + '\n\n' + content;
+  
+  if (transformed) {
+    if (tocPosition.start.range[0] > 0) { data.push(content.slice(0, tocPosition.start.range[0])); }
+    data.push(wrappedToc);
+    if (!tocPosition.existing) { data.push(''); }
+    data.push(content.slice(tocPosition.end.range[1] + (tocPosition.existing ? 1 : 0)));
   }
-  else if (transformed){
-    data = content.slice(0, tocPosition.start.range[0]) +
-      wrappedToc + '\n' + 
-      content.slice(tocPosition.end.range[1] + 1);
-  }
-  return { transformed : transformed, data : data, toc: toc, wrappedToc: wrappedToc };
+  return { transformed : transformed, data : data.join('\n'), toc: toc, wrappedToc: wrappedToc };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "anchor-markdown-header": "^0.8.3",
         "htmlparser2": "^7.2.0",
         "loglevel": "^1.9.2",
-        "minimist": "^1.2.6",
-        "update-section": "^0.3.3"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "doctoc": "doctoc.js"
@@ -4634,11 +4633,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/update-section": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
-      "integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg="
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "anchor-markdown-header": "^0.8.3",
     "htmlparser2": "^7.2.0",
     "loglevel": "^1.9.2",
-    "minimist": "^1.2.6",
-    "update-section": "^0.3.3"
+    "minimist": "^1.2.6"
   },
   "devDependencies": {
     "tap": "^21.5.0"

--- a/test/transform.js
+++ b/test/transform.js
@@ -795,9 +795,6 @@ test('should use {/* */} comments if syntax=mdx', function (t) {
     t.end()
 })
 
-// Bug: compact pragma style with existing toc crashes because .replace() is called
-// on an AST node (object) instead of node.raw (string). This is a regression
-// introduced by the refactor — it passes on master.
 test('compact pragma style with existing toc', function (t) {
   var md = [
       '<!-- START doctoc generated TOC please keep comment here to allow auto update -->'

--- a/test/transform.js
+++ b/test/transform.js
@@ -795,6 +795,65 @@ test('should use {/* */} comments if syntax=mdx', function (t) {
     t.end()
 })
 
+// Bug: compact pragma style with existing toc crashes because .replace() is called
+// on an AST node (object) instead of node.raw (string). This is a regression
+// introduced by the refactor — it passes on master.
+test('compact pragma style with existing toc', function (t) {
+  var md = [
+      '<!-- START doctoc generated TOC please keep comment here to allow auto update -->'
+    , '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'
+    , '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*'
+    , ''
+    , '- [Header](#header)'
+    , ''
+    , '<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
+    , ''
+    , '## Header'
+    , 'some content'
+    ].join('\n')
+
+  var res = transform(md
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , undefined
+    , { toc: { pragma: { style: 'compact' } } }
+  )
+
+  t.same(
+      res.wrappedToc.split('\n')
+    , [ '<!-- START doctoc -->',
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '- [Header](#header)',
+        '',
+        '<!-- END doctoc -->' ]
+    , 'compacts the pragma markers'
+  )
+
+  t.same(
+      res.data.split('\n')
+    , [ '<!-- START doctoc -->',
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '- [Header](#header)',
+        '',
+        '<!-- END doctoc -->',
+        '',
+        '## Header',
+        'some content' ]
+    , 'replaces verbose markers with compact ones'
+  )
+  t.end()
+})
+
+
 test('\nduplicate titles but with different symbols', function (t) {
   var content = require('fs').readFileSync(__dirname + '/fixtures/readme-with-duplicate-headers.md', 'utf8');
   var headers = transform(content);


### PR DESCRIPTION
Progresses #153
Progresses #258
Progresses #279

This works to further improve the code path and reduce un-necessary operations during the file handling process.

Previously we had:
- File content was being read
- content was being split based on EOL
- content was being parsed line by line looking for toc
- file content was transformed to ast to get markdown headers
- file content was transformed to ast to get html headers
- toc string built
- toc split into lines
- toc lines spliced into content lines
- content lines merged back into content

Now we just have

- File content was being read
- file content was transformed to ast
- get toc from ast
- get markdown headers from ast
- get html headers from ast
- toc string built
- content built by merging content to prior old toc, new toc & after old toc.

Hence with this new approach the transformation is reduced & ensures that we only touch the toc and not the entire doc.

This will hopefully improve performance of larger files.
