### PR TITLE
fix: line endings are set based on file

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -224,11 +224,11 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     tocLines.push('');
     if (options?.toc?.footer?.content) { tocLines.push(options.toc.footer.content); }
 
-    toc = tocLines.join('\n').trimEnd();
+    toc = tocLines.join('\n');
   }
 
   var data = [];
-  var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n\n' : '') + tocPosition.end.raw;
+  var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n' : '') + tocPosition.end.raw;
   var transformed = !tocPosition?.existing || content.slice(tocPosition.start.range[0], tocPosition.end.range[1]) != wrappedToc;
   
   if (transformed) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -224,11 +224,11 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     tocLines.push('');
     if (options?.toc?.footer?.content) { tocLines.push(options.toc.footer.content); }
 
-    toc = tocLines.join('\n');
+    toc = tocLines.join('\n').trimEnd();
   }
 
   var data = [];
-  var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n' : '') + tocPosition.end.raw;
+  var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n\n' : '') + tocPosition.end.raw;
   var transformed = !tocPosition?.existing || content.slice(tocPosition.start.range[0], tocPosition.end.range[1]) != wrappedToc;
   
   if (transformed) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -172,7 +172,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     }
 
     if (options?.toc?.header?.content) { tocL.push(options.toc.header.content); }
-    if (padTitle) { tocL.push(''); }
+    if (padTitle && inferredTitle) { tocL.push(''); }
     if (inferredTitle) { tocL.push(inferredTitle); }
     tocL.push('');
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -144,30 +144,9 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
   return paragraphs?.[paragraphs.length - 1]?.raw;
 }
 
-function detectLineEnding(content, defaultEol) {
-  var eol = '', newEol = '';
-
-  for (var i = 0; i < content.length; i++) {
-    if (content[i] === '\r') {
-      if (content[i + 1] === '\n') {
-        newEol = '\r\n';
-        i++;
-      }
-      else { newEol = '\r'; }
-    }
-    else if (content[i] === '\n') { newEol = '\n'; }
-    else { continue; }
-    if (eol && eol != newEol) { return defaultEol; }
-    eol = newEol;
-  }
-
-  return eol || defaultEol;
-}
-
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
   var eol = '\n';
-  eol = detectLineEnding(content, eol);
   var skipTag = contentGenerator.skipTag(syntax) + eol;
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -146,6 +146,7 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
+  var eol = '\n';
   var skipTag = contentGenerator.skipTag(syntax) + '\n';
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === '\n')) return { transformed: false };
@@ -237,5 +238,5 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (!tocPosition.existing) { data.push(''); }
     data.push(content.slice(tocPosition.end.range[1] + (tocPosition.existing ? 1 : 0)));
   }
-  return { transformed : transformed, data : data.join('\n'), toc: toc, wrappedToc: wrappedToc };
+  return { transformed : transformed, data : data.join(eol), toc: toc, wrappedToc: wrappedToc, eol: eol };
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -242,11 +242,11 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     tocL.push('');
     if (options?.toc?.footer?.content) { tocL.push(options.toc.footer.content); }
 
-    toc = tocL.join('\n');
+    toc = tocL.join(eol);
   }
 
   var data = [];
-  var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n' : '') + tocPosition.end.raw;
+  var wrappedToc = tocPosition.start.raw + eol + (toc != '' ? toc + eol : '') + tocPosition.end.raw;
   var transformed = !tocPosition?.existing || content.slice(tocPosition.start.range[0], tocPosition.end.range[1]) != wrappedToc;
   
   if (transformed) {
@@ -255,5 +255,5 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (!tocPosition.existing) { data.push(''); }
     data.push(content.slice(tocPosition.end.range[1] + (tocPosition.existing ? 1 : 0)));
   }
-  return { transformed : transformed, data : data.join('\n'), toc: toc, wrappedToc: wrappedToc };
+  return { transformed : transformed, data : data.join(eol), toc: toc, wrappedToc: wrappedToc };
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -126,9 +126,9 @@ function detectLineEnding(content) {
   // Count all \r, then subtract CRLF occurrences
   const cr = (content.match(/\r/g) || []).length - crlf;
 
-  if (crlf > lf && crlf > cr) return '\r\n';
-  if (lf > crlf && lf > cr)   return '\n';
-  if (cr > crlf && cr > lf)   return '\r';
+  if (lf + cr === 0 && crlf > 0)   return '\r\n';
+  if (crlf + cr === 0 && lf > 0)   return '\n';
+  if (crlf + lf === 0 && cr > 0)   return '\r';
 
   return '\n';
 }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -117,13 +117,30 @@ function determineTitle(title, notitle, lines, info) {
   return readTitle != "" || previousLine.includes("END doctoc") ? readTitle : previousLine;
 }
 
+function detectLineEnding(content) {
+  const crlf = (content.match(/\r\n/g) || []).length;
+
+  // Count all \n, then subtract CRLF occurrences
+  const lf = (content.match(/\n/g) || []).length - crlf;
+
+  // Count all \r, then subtract CRLF occurrences
+  const cr = (content.match(/\r/g) || []).length - crlf;
+
+  if (crlf > lf && crlf > cr) return '\r\n';
+  if (lf > crlf && lf > cr)   return '\n';
+  if (cr > crlf && cr > lf)   return '\r';
+
+  return '\n';
+}
+
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
-  var skipTag = contentGenerator.skipTag(syntax) + '\n';
+  var eol = detectLineEnding(content);
+  var skipTag = contentGenerator.skipTag(syntax) + eol;
   var matchesStartBySyntax = matchesStart(syntax);
   var matchesEndBySyntax = matchesEnd(syntax);
   var index = content.indexOf(skipTag);
-  if (index === 0 || (index >= 0 && content[index-1] === '\n')) return { transformed: false };
+  if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };
 
   mode = mode || "github.com";
   entryPrefix = entryPrefix || "-";

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -181,7 +181,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
           return indentation.repeat((x.rank - lowestRank) * indentationWidth) + entryPrefix + ' ' + x.anchor;
         }));
 
-    if (options?.toc?.footer?.content) { tocL.push(''); }
+    tocL.push('');
     if (options?.toc?.footer?.content) { tocL.push(options.toc.footer.content); }
 
     toc = tocL.join('\n');

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -165,13 +165,13 @@ function detectLineEnding(content, defaultEol) {
     eol = newEol;
   }
 
-  if (title && header?.includes(title)) return "";
-  return title || "";
+  return eol || defaultEol;
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
   var eol = '\n';
+  eol = detectLineEnding(content, eol);
   var skipTag = contentGenerator.skipTag(syntax) + eol;
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -195,10 +195,9 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel));
 
   var toc = '';
-  var wrappedToc;
 
   if (headers.length >= minTocItems) {
-    var tocL = [];
+    var tocLines = [];
     var inferredTitle = determineTitle(docNodes, tocPosition, title, notitle, syntax);
     
     var allHeaders = processHeaders(headers, mode);
@@ -212,20 +211,20 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
       indentationWidth = (mode === 'bitbucket.org' || mode === 'gitlab.com') ? 4 : 2;
     }
 
-    if (options?.toc?.header?.content) { tocL.push(options.toc.header.content); }
-    if (padTitle && inferredTitle) { tocL.push(''); }
-    if (inferredTitle) { tocL.push(inferredTitle); }
-    tocL.push('');
+    if (options?.toc?.header?.content) { tocLines.push(options.toc.header.content); }
+    if (padTitle && inferredTitle) { tocLines.push(''); }
+    if (inferredTitle) { tocLines.push(inferredTitle); }
+    tocLines.push('');
 
-    tocL.push(...allHeaders
+    tocLines.push(...allHeaders
         .map(function (x) {
           return indentation.repeat((x.rank - lowestRank) * indentationWidth) + entryPrefix + ' ' + x.anchor;
         }));
 
-    tocL.push('');
-    if (options?.toc?.footer?.content) { tocL.push(options.toc.footer.content); }
+    tocLines.push('');
+    if (options?.toc?.footer?.content) { tocLines.push(options.toc.footer.content); }
 
-    toc = tocL.join('\n');
+    toc = tocLines.join('\n');
   }
 
   var data = [];

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -166,7 +166,8 @@ function detectLineEnding(content, defaultEol) {
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
-  var eol = detectLineEnding(content, '\n');
+  var eol = '\n';
+  eol = detectLineEnding(content, eol);
   var skipTag = contentGenerator.skipTag(syntax) + eol;
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -187,7 +187,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     toc = tocL.join('\n');
   }
 
-  var wrappedToc = wrappedToc = tocs.expected.start + '\n' + (toc != '' ? toc + '\n' : '') + tocs.expected.end;
+  var wrappedToc = start + '\n' + (toc != '' ? toc + '\n' : '') + end;
   var transformed = !info.hasStart || lines.slice(info.startIdx, info.endIdx + 1).join('\n') != wrappedToc;
 
   var data;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -259,5 +259,5 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (!tocPosition.existing) { data.push(''); }
     data.push(content.slice(tocPosition.end.range[1] + (tocPosition.existing ? 1 : 0)));
   }
-  return { transformed : transformed, data : data.join(eol), toc: toc, wrappedToc: wrappedToc };
+  return { transformed : transformed, data : data.join(eol), toc: toc, wrappedToc: wrappedToc, eol: eol };
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -155,13 +155,9 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml, minHeaderLevel));
 
   var toc = '';
-  var wrappedToc;
 
   if (headers.length >= minTocItems) {
-    if (options?.toc?.header?.content) {
-      start = start + '\n' + options.toc.header.content;
-    }
-
+    var tocL = [];
     var inferredTitle = determineTitle(title, notitle, lines, info);
     
     var allHeaders = processHeaders(headers, mode);
@@ -174,31 +170,27 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
       // 4 spaces required for proper indention on Bitbucket and GitLab
       indentationWidth = (mode === 'bitbucket.org' || mode === 'gitlab.com') ? 4 : 2;
     }
-    
-    if (inferredTitle) {
-      toc = (padTitle ? '\n' : '') + inferredTitle + '\n';
-    }
 
-    toc = toc + '\n'
-    + allHeaders
+    if (options?.toc?.header?.content) { tocL.push(options.toc.header.content); }
+    if (padTitle) { tocL.push(''); }
+    if (inferredTitle) { tocL.push(inferredTitle); }
+    tocL.push('');
+
+    tocL.push(...allHeaders
         .map(function (x) {
           return indentation.repeat((x.rank - lowestRank) * indentationWidth) + entryPrefix + ' ' + x.anchor;
-        })
-        .join('\n')
-    + '\n';
-    
-    if (options?.toc?.footer?.content) {
-      end = options.toc.footer.content + '\n' + end;
-    }
-    
-    wrappedToc = start + '\n' + toc + '\n' + end;
-  }
-  else {
-    wrappedToc =  start + '\n' + end;
+        }));
+
+    if (options?.toc?.footer?.content) { tocL.push(''); }
+    if (options?.toc?.footer?.content) { tocL.push(options.toc.footer.content); }
+
+    toc = tocL.join('\n');
   }
 
-  var data;
+  var wrappedToc = wrappedToc = tocs.expected.start + '\n' + (toc != '' ? toc + '\n' : '') + tocs.expected.end;
   var transformed = !info.hasStart || lines.slice(info.startIdx, info.endIdx + 1).join('\n') != wrappedToc;
+
+  var data;
   if (!info.hasStart) {
     data = wrappedToc + '\n\n' + content;
   }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -246,7 +246,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     tocLines.push('');
     if (options?.toc?.footer?.content) { tocLines.push(options.toc.footer.content); }
 
-    toc = tocL.join(eol);
+    toc = tocLines.join(eol);
   }
 
   var data = [];

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -155,6 +155,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     .concat(getHtmlHeaders(linesToToc, maxHeaderLevelHtml, minHeaderLevel));
 
   var toc = '';
+  var wrappedToc;
 
   if (headers.length >= minTocItems) {
     var tocL = [];
@@ -185,9 +186,12 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (options?.toc?.footer?.content) { tocL.push(options.toc.footer.content); }
 
     toc = tocL.join('\n');
+    wrappedToc = start + '\n' + toc + '\n' + end;
+  }
+  else {
+    wrappedToc =  start + '\n' + end;
   }
 
-  var wrappedToc = start + '\n' + (toc != '' ? toc + '\n' : '') + end;
   var transformed = !info.hasStart || lines.slice(info.startIdx, info.endIdx + 1).join('\n') != wrappedToc;
 
   var data;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -228,21 +228,6 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     toc = tocL.join('\n');
     wrappedToc = start + '\n' + toc + '\n' + end;
   }
-  else {
-    wrappedToc =  start + '\n' + end;
-  }
-
-  var transformed = !info.hasStart || lines.slice(info.startIdx, info.endIdx + 1).join('\n') != wrappedToc;
-
-  var data;
-  if (!info.hasStart) {
-    data = wrappedToc + '\n\n' + content;
-  }
-  else if (transformed){
-    var sectionLines = wrappedToc.split('\n'),
-      dropN = info.endIdx - info.startIdx + 1;
-
-    [].splice.apply(lines, [ info.startIdx, dropN ].concat(sectionLines));
 
   var data = [];
   var wrappedToc = tocPosition.start.raw + '\n' + (toc != '' ? toc + '\n' : '') + tocPosition.end.raw;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -144,7 +144,7 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
   return paragraphs?.[paragraphs.length - 1]?.raw;
 }
 
-function detectLineEnding(content, default) {
+function detectLineEnding(content, defaultEol) {
   var eol = '', newEol = '';
 
   for (var i = 0; i < content.length; i++) {
@@ -157,11 +157,11 @@ function detectLineEnding(content, default) {
     }
     else if (content[i] === '\n') { newEol = '\n'; }
     else { continue; }
-    if (eol && eol != newEol) { return default; }
+    if (eol && eol != newEol) { return defaultEol; }
     eol = newEol;
   }
 
-  return eol || default;
+  return eol || defaultEol;
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -144,9 +144,30 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
   return paragraphs?.[paragraphs.length - 1]?.raw;
 }
 
+function detectLineEnding(content, defaultEol) {
+  var eol = '', newEol = '';
+
+  for (var i = 0; i < content.length; i++) {
+    if (content[i] === '\r') {
+      if (content[i + 1] === '\n') {
+        newEol = '\r\n';
+        i++;
+      }
+      else { newEol = '\r'; }
+    }
+    else if (content[i] === '\n') { newEol = '\n'; }
+    else { continue; }
+    if (eol && eol != newEol) { return defaultEol; }
+    eol = newEol;
+  }
+
+  return eol || defaultEol;
+}
+
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
   var eol = '\n';
+  eol = detectLineEnding(content, eol);
   var skipTag = contentGenerator.skipTag(syntax) + eol;
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -145,13 +145,18 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
 }
 
 function detectLineEnding(content) {
-  const crlf = (content.match(/\r\n/g) || []).length;
+  var crlf = 0, lf = 0, cr = 0;
 
-  // Count all \n, then subtract CRLF occurrences
-  const lf = (content.match(/\n/g) || []).length - crlf;
-
-  // Count all \r, then subtract CRLF occurrences
-  const cr = (content.match(/\r/g) || []).length - crlf;
+  for (var i = 0; i < content.length; i++) {
+    if (content[i] === '\r') {
+      if (content[i + 1] === '\n') {
+        crlf++;
+        i++;
+      }
+      else { cr++; }
+    }
+    else if (content[i] === '\n') { lf++; }
+  }
 
   if (lf + cr === 0 && crlf > 0)   return '\r\n';
   if (crlf + cr === 0 && lf > 0)   return '\n';

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -144,8 +144,8 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
   return paragraphs?.[paragraphs.length - 1]?.raw;
 }
 
-function detectLineEnding(content) {
-  var eol = '', newEol = '', default = '\n';
+function detectLineEnding(content, default) {
+  var eol = '', newEol = '';
 
   for (var i = 0; i < content.length; i++) {
     if (content[i] === '\r') {
@@ -166,7 +166,7 @@ function detectLineEnding(content) {
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   syntax = syntax || "md";
-  var eol = detectLineEnding(content);
+  var eol = detectLineEnding(content, '\n');
   var skipTag = contentGenerator.skipTag(syntax) + eol;
   var index = content.indexOf(skipTag);
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -145,24 +145,23 @@ function determineTitle(nodes, tocPosition, title, notitle, syntax) {
 }
 
 function detectLineEnding(content) {
-  var crlf = 0, lf = 0, cr = 0;
+  var eol = '', newEol = '', default = '\n';
 
   for (var i = 0; i < content.length; i++) {
     if (content[i] === '\r') {
       if (content[i + 1] === '\n') {
-        crlf++;
+        newEol = '\r\n';
         i++;
       }
-      else { cr++; }
+      else { newEol = '\r'; }
     }
-    else if (content[i] === '\n') { lf++; }
+    else if (content[i] === '\n') { newEol = '\n'; }
+    else { continue; }
+    if (eol && eol != newEol) { return default; }
+    eol = newEol;
   }
 
-  if (lf + cr === 0 && crlf > 0)   return '\r\n';
-  if (crlf + cr === 0 && lf > 0)   return '\n';
-  if (crlf + lf === 0 && cr > 0)   return '\r';
-
-  return '\n';
+  return eol || default;
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -226,7 +226,6 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (options?.toc?.footer?.content) { tocL.push(options.toc.footer.content); }
 
     toc = tocL.join('\n');
-    wrappedToc = start + '\n' + toc + '\n' + end;
   }
 
   var data = [];

--- a/test/transform.js
+++ b/test/transform.js
@@ -12,8 +12,8 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
     var contents = anchors.split('\n').slice(0, -2);
-    var toc = pragma.start + '\n' + anchors + '\n' + pragma.end;
-    var doc = res.wrappedToc + '\n' + md;
+    var toc = pragma.start + '\n' + anchors.trimEnd() + '\n\n' + pragma.end;
+    var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
     t.same(contents, res.toc.split('\n'), 'generates correct toc contents');

--- a/test/transform.js
+++ b/test/transform.js
@@ -17,7 +17,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 
     t.ok(res.transformed, 'transforms it');
     t.same(contents, res.toc.split('\n'), 'generates correct toc contents');
-    t.same(toc, res.data, 'generates correct toc');
+    t.same(toc, res.wrappedToc, 'generates correct toc');
     t.same(doc, res.data, 'generates correct doc');
     t.end()
   })

--- a/test/transform.js
+++ b/test/transform.js
@@ -15,7 +15,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(res.toc, anchors.trimEnd(), 'generates correct toc contents');
+    t.same(res.toc, anchors.trimEnd() + '\n\n', 'generates correct toc contents');
     t.same(res.wrappedToc, toc, 'generates correct toc');
     t.same(res.data, doc, 'generates correct doc');
     t.end()

--- a/test/transform.js
+++ b/test/transform.js
@@ -15,9 +15,9 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(anchors, res.toc, 'generates correct toc contents');
-    t.same(toc, res.wrappedToc, 'generates correct toc');
-    t.same(doc, res.data, 'generates correct doc');
+    t.same(res.toc, anchors.trimEnd(), 'generates correct toc contents');
+    t.same(res.wrappedToc, toc, 'generates correct toc');
+    t.same(res.data, doc, 'generates correct doc');
     t.end()
   })
 }

--- a/test/transform.js
+++ b/test/transform.js
@@ -11,11 +11,13 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
+    var contents =  anchors.trimEnd();
+    if (contents != '') { contents += '\n'; }
     var toc = pragma.start + '\n' + anchors.trimEnd() + (anchors ? '\n\n': '') + pragma.end;
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(res.toc, anchors.trimEnd() + '\n', 'generates correct toc contents');
+    t.same(res.toc, contents, 'generates correct toc contents');
     t.same(res.wrappedToc, toc, 'generates correct toc');
     t.same(res.data, doc, 'generates correct doc');
     t.end()

--- a/test/transform.js
+++ b/test/transform.js
@@ -50,6 +50,25 @@ check(
 )
 
 check(
+    [ '# My Module using \\r line endings'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this'
+    , '### Method Two'
+    , '#### Main Usage'
+    , 'some main usage here'
+    ].join('\r')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\r'
+    , '- [My Module using \\r line endings](#my-module-using-r-line-endings)\r'
+    ,   '  - [API](#api)\r'
+    ,     '    - [Method One](#method-one)\r'
+    ,     '    - [Method Two](#method-two)\r'
+    ,         '      - [Main Usage](#main-usage)\r\r\r'
+    ].join('')
+)
+
+check(
     [ '# My Module using \\r\\n line endings'
     , 'Some text here'
     , '## API'
@@ -60,7 +79,25 @@ check(
     , 'some main usage here'
     ].join('\r\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\n\r\n'
-    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'
+    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'    ,   '  - [API](#api)\r\n'
+    ,     '    - [Method One](#method-one)\r\n'
+    ,     '    - [Method Two](#method-two)\r\n'
+    ,         '      - [Main Usage](#main-usage)\r\n\r\n\r\n'
+    ].join('')
+)
+
+check(
+    [ '# My Module using mixed line endings\r'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this\r'
+    , '### Method Two'
+    , '#### Main Usage\r'
+    , 'some main usage here'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [My Module using mixed line endings](#my-module-using-mixed-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -78,8 +78,27 @@ check(
     , '#### Main Usage'
     , 'some main usage here'
     ].join('\r\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\n\r\n'
+    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'
+    ,   '  - [API](#api)\r\n'
+    ,     '    - [Method One](#method-one)\r\n'
+    ,     '    - [Method Two](#method-two)\r\n'
+    ,         '      - [Main Usage](#main-usage)\r\n\r\n\r\n'
+    ].join('')
+)
+
+check(
+    [ '# My Module using mixed line endings\r'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this\r'
+    , '### Method Two'
+    , '#### Main Usage\r'
+    , 'some main usage here'
+    ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\n'
+    , '- [My Module using mixed line endings](#my-module-using-mixed-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -50,26 +50,6 @@ check(
 )
 
 check(
-    [ '# My Module using \\r line endings'
-    , 'Some text here'
-    , '## API'
-    , '### Method One'
-    , 'works like this'
-    , '### Method Two'
-    , '#### Main Usage'
-    , 'some main usage here'
-    ].join('\r')
-  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\r'
-    , '- [My Module using \\r line endings](#my-module-using-r-line-endings)\r'
-    ,   '  - [API](#api)\r'
-    ,     '    - [Method One](#method-one)\r'
-    ,     '    - [Method Two](#method-two)\r'
-    ,         '      - [Main Usage](#main-usage)\r\r\r'
-    ].join('')
-)
-
-
-check(
     [ '# My Module using \\r\\n line endings'
     , 'Some text here'
     , '## API'
@@ -81,25 +61,6 @@ check(
     ].join('\r\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\n\r\n'
     , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'
-    ,   '  - [API](#api)\r\n'
-    ,     '    - [Method One](#method-one)\r\n'
-    ,     '    - [Method Two](#method-two)\r\n'
-    ,         '      - [Main Usage](#main-usage)\r\n\r\n\r\n'
-    ].join('')
-)
-
-check(
-    [ '# My Module using mixed line endings\r'
-    , 'Some text here'
-    , '## API'
-    , '### Method One'
-    , 'works like this\r'
-    , '### Method Two'
-    , '#### Main Usage\r'
-    , 'some main usage here'
-    ].join('\n')
-  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '- [My Module using mixed line endings](#my-module-using-mixed-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -15,7 +15,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(res.toc, anchors.trimEnd() + '\n\n', 'generates correct toc contents');
+    t.same(res.toc, anchors.trimEnd() + '\n\n\n', 'generates correct toc contents');
     t.same(res.wrappedToc, toc, 'generates correct toc');
     t.same(res.data, doc, 'generates correct doc');
     t.end()

--- a/test/transform.js
+++ b/test/transform.js
@@ -13,11 +13,11 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var data = res.data.split(res.eol);
 
     // rig our expected value to include the wrapper
-    var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
-    var startLines = pragma.start.split(/\r\n|\n|\r/)
-      , anchorLines = anchors.split(/\r\n|\n|\r/)
-      , endLines = pragma.end.split(/\r\n|\n|\r/)
-      , mdLines = md.split(/\r\n|\n|\r/);
+    var legacy = contentGenerator.pragmaMarkers(syntax || 'md');
+    var startLines = legacy.start.split('\n')
+      , anchorLines = anchors.split('\n')
+      , endLines = legacy.end.split('\n')
+      , mdLines = md.split('\n');
 
     var rig = startLines
       .concat(anchorLines.slice(0, -2))

--- a/test/transform.js
+++ b/test/transform.js
@@ -59,8 +59,8 @@ check(
     , '#### Main Usage'
     , 'some main usage here'
     ].join('\r\n')
-  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\n\r\n'
-    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -15,7 +15,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(res.toc, anchors.trimEnd() + '\n\n\n', 'generates correct toc contents');
+    t.same(res.toc, anchors.trimEnd() + '\n', 'generates correct toc contents');
     t.same(res.wrappedToc, toc, 'generates correct toc');
     t.same(res.data, doc, 'generates correct doc');
     t.end()

--- a/test/transform.js
+++ b/test/transform.js
@@ -12,9 +12,9 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
     var contents =  anchors.trimEnd();
-    if (contents != '') { contents += '\n'; }
-    var toc = pragma.start + '\n' + anchors.trimEnd() + (anchors ? '\n\n': '') + pragma.end;
-    var doc = res.wrappedToc + '\n\n' + md;
+    if (contents != '') { contents += res.eol; }
+    var toc = pragma.start + res.eol + anchors.trimEnd() + (anchors ? res.eol + res.eol : '') + pragma.end;
+    var doc = res.wrappedToc + res.eol + res.eol + md;
 
     t.ok(res.transformed, 'transforms it');
     t.same(res.toc, contents, 'generates correct toc contents');

--- a/test/transform.js
+++ b/test/transform.js
@@ -10,14 +10,15 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var res = transform(md, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options)
 
     // remove wrapper
-    var data = res.data.split('\n');
+    var eol = res.eol;
+    var data = res.data.split(eol);
 
     // rig our expected value to include the wrapper
-    var legacy = contentGenerator.pragmaMarkers(syntax || 'md');
-    var startLines = legacy.start.split('\n')
-      , anchorLines = anchors.split('\n')
-      , endLines = legacy.end.split('\n')
-      , mdLines = md.split('\n');
+    var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
+    var startLines = pragma.start.split(eol)
+      , anchorLines = anchors.split(eol)
+      , endLines = pragma.end.split(eol)
+      , mdLines = md.split(eol);
 
     var rig = startLines
       .concat(anchorLines.slice(0, -2))
@@ -32,7 +33,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 }
 
 function getCommentLines(transformRes){
-    var lines = transformRes.wrappedToc.split('\n')
+    var lines = transformRes.wrappedToc.split(transformRes.eol)
     return lines.slice(0,2).concat(lines[lines.length - 1])
 }
 //function check() {}
@@ -48,7 +49,7 @@ check(
     , 'some main usage here'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '- [My Module \\n line endings](#my-module-using-n-line-endings)\n'
+    , '- [My Module using \\n line endings](#my-module-using-n-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -9,24 +9,16 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
   test('transforming', function (t) {
     var res = transform(md, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options)
 
-    // remove wrapper
-    var data = res.data.split('\n');
-
-    // rig our expected value to include the wrapper
-    var legacy = contentGenerator.pragmaMarkers(syntax || 'md');
-    var startLines = legacy.start.split('\n')
-      , anchorLines = anchors.split('\n')
-      , endLines = legacy.end.split('\n')
-      , mdLines = md.split('\n');
-
-    var rig = startLines
-      .concat(anchorLines.slice(0, -2))
-      .concat(endLines)
-      .concat('')
-      .concat(mdLines);
+    // build the expected content
+    var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
+    var contents = anchors.split('\n').slice(0, -2);
+    var toc = pragma.start + '\n' + anchors + '\n' + pragma.end;
+    var doc = res.wrappedToc + '\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(data, rig, 'generates correct anchors')
+    t.same(contents, res.toc.split('\n'), 'generates correct toc contents');
+    t.same(toc, res.data, 'generates correct toc');
+    t.same(doc, res.data, 'generates correct doc');
     t.end()
   })
 }

--- a/test/transform.js
+++ b/test/transform.js
@@ -79,7 +79,8 @@ check(
     , 'some main usage here'
     ].join('\r\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\n\r\n'
-    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'    ,   '  - [API](#api)\r\n'
+    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'
+    ,   '  - [API](#api)\r\n'
     ,     '    - [Method One](#method-one)\r\n'
     ,     '    - [Method Two](#method-two)\r\n'
     ,         '      - [Main Usage](#main-usage)\r\n\r\n\r\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -38,7 +38,7 @@ function getCommentLines(transformRes){
 //function check() {}
 
 check(
-    [ '# My Module'
+    [ '# My Module using \\n line endings'
     , 'Some text here'
     , '## API'
     , '### Method One'
@@ -48,13 +48,33 @@ check(
     , 'some main usage here'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '- [My Module](#my-module)\n'
+    , '- [My Module \\n line endings](#my-module-using-n-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'
     ,         '      - [Main Usage](#main-usage)\n\n\n'
     ].join('')
 )
+
+check(
+    [ '# My Module using \\r line endings'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this'
+    , '### Method Two'
+    , '#### Main Usage'
+    , 'some main usage here'
+    ].join('\r')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\r'
+    , '- [My Module using \\r line endings](#my-module-using-r-line-endings)\r'
+    ,   '  - [API](#api)\r'
+    ,     '    - [Method One](#method-one)\r'
+    ,     '    - [Method Two](#method-two)\r'
+    ,         '      - [Main Usage](#main-usage)\r\r\r'
+    ].join('')
+)
+
 
 check(
     [ '# My Module using \\r\\n line endings'
@@ -66,8 +86,27 @@ check(
     , '#### Main Usage'
     , 'some main usage here'
     ].join('\r\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\r\n\r\n'
+    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\r\n'
+    ,   '  - [API](#api)\r\n'
+    ,     '    - [Method One](#method-one)\r\n'
+    ,     '    - [Method Two](#method-two)\r\n'
+    ,         '      - [Main Usage](#main-usage)\r\n\r\n\r\n'
+    ].join('')
+)
+
+check(
+    [ '# My Module using mixed line endings\r'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this\r'
+    , '### Method Two'
+    , '#### Main Usage\r'
+    , 'some main usage here'
+    ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '- [My Module using \\r\\n line endings](#my-module-using-rn-line-endings)\n'
+    , '- [My Module using mixed line endings](#my-module-using-mixed-line-endings)\n'
     ,   '  - [API](#api)\n'
     ,     '    - [Method One](#method-one)\n'
     ,     '    - [Method Two](#method-two)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -26,7 +26,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 }
 
 function getCommentLines(transformRes){
-    var lines = transformRes.wrappedToc.split(transformRes.eol)
+    var lines = transformRes.wrappedToc.split('\n')
     return lines.slice(0,2).concat(lines[lines.length - 1])
 }
 //function check() {}

--- a/test/transform.js
+++ b/test/transform.js
@@ -12,7 +12,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
     var contents = anchors.split('\n').slice(0, -2);
-    var toc = pragma.start + '\n' + anchors.trim() + '\n' + pragma.end;
+    var toc = pragma.start + '\n' + anchors.trim() + '\n\n' + pragma.end;
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');

--- a/test/transform.js
+++ b/test/transform.js
@@ -10,15 +10,14 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     var res = transform(md, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options)
 
     // remove wrapper
-    var eol = res.eol;
-    var data = res.data.split(eol);
+    var data = res.data.split(res.eol);
 
     // rig our expected value to include the wrapper
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
-    var startLines = pragma.start.split(eol)
-      , anchorLines = anchors.split(eol)
-      , endLines = pragma.end.split(eol)
-      , mdLines = md.split(eol);
+    var startLines = pragma.start.split(/\r\n|\n|\r/)
+      , anchorLines = anchors.split(/\r\n|\n|\r/)
+      , endLines = pragma.end.split(/\r\n|\n|\r/)
+      , mdLines = md.split(/\r\n|\n|\r/);
 
     var rig = startLines
       .concat(anchorLines.slice(0, -2))

--- a/test/transform.js
+++ b/test/transform.js
@@ -12,7 +12,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
     var contents = anchors.split('\n').slice(0, -2);
-    var toc = pragma.start + '\n' + anchors.trimEnd() + '\n\n' + pragma.end;
+    var toc = pragma.start + '\n' + anchors.trim() + '\n' + pragma.end;
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');

--- a/test/transform.js
+++ b/test/transform.js
@@ -11,12 +11,11 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
-    var contents = anchors.split('\n').slice(0, -2);
     var toc = pragma.start + '\n' + anchors.trimEnd() + (anchors ? '\n\n': '') + pragma.end;
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(anchors.trimEnd(), res.toc, 'generates correct toc contents');
+    t.same(anchors, res.toc, 'generates correct toc contents');
     t.same(toc, res.wrappedToc, 'generates correct toc');
     t.same(doc, res.data, 'generates correct doc');
     t.end()

--- a/test/transform.js
+++ b/test/transform.js
@@ -47,6 +47,18 @@ check(
     ,     '    - [Method Two](#method-two)\n'
     ,         '      - [Main Usage](#main-usage)\n\n\n'
     ].join('')
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , '\n'
 )
 
 check(
@@ -66,6 +78,18 @@ check(
     ,     '    - [Method Two](#method-two)\r'
     ,         '      - [Main Usage](#main-usage)\r\r\r'
     ].join('')
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , '\r'
 )
 
 check(
@@ -85,6 +109,18 @@ check(
     ,     '    - [Method Two](#method-two)\r\n'
     ,         '      - [Main Usage](#main-usage)\r\n\r\n\r\n'
     ].join('')
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , '\r\n'
 )
 
 check(
@@ -104,6 +140,18 @@ check(
     ,     '    - [Method Two](#method-two)\n'
     ,         '      - [Main Usage](#main-usage)\n\n\n'
     ].join('')
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , '\n'
 )
 
 check(

--- a/test/transform.js
+++ b/test/transform.js
@@ -12,11 +12,11 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
     // build the expected content
     var pragma = contentGenerator.pragmaMarkers(syntax || 'md');
     var contents = anchors.split('\n').slice(0, -2);
-    var toc = pragma.start + '\n' + anchors.trim() + '\n\n' + pragma.end;
+    var toc = pragma.start + '\n' + anchors.trimEnd() + (anchors ? '\n\n': '') + pragma.end;
     var doc = res.wrappedToc + '\n\n' + md;
 
     t.ok(res.transformed, 'transforms it');
-    t.same(contents, res.toc.split('\n'), 'generates correct toc contents');
+    t.same(anchors.trimEnd(), res.toc, 'generates correct toc contents');
     t.same(toc, res.wrappedToc, 'generates correct toc');
     t.same(doc, res.data, 'generates correct doc');
     t.end()


### PR DESCRIPTION
Closes: #161 
Closes: #216

Tool now detects what line endings have been used in the content and uses that in the generated toc to strive for consistency.

Blocked by: #337 & #338