### PR TITLE
test: Add Empty file test

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -176,8 +176,6 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     padTitle = notitle || false;
   }
 
-  var hasBody = docNodes.children.length > 0;
-
   // only limit *HTML* headings by default
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
 
@@ -188,6 +186,8 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (!(tocs.positions?.length > 0) && updateOnly) {
     return { transformed: false };
   }
+  
+  var hasBody = docNodes.children.length > 0;
   
   if (!(tocs.positions?.length > 0)) {
     var insertPos = 0;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -176,6 +176,8 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     padTitle = notitle || false;
   }
 
+  var hasBody = docNodes.children.length > 0;
+
   // only limit *HTML* headings by default
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
 
@@ -252,7 +254,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (transformed) {
     if (tocPosition.start.range[0] > 0) { data.push(content.slice(0, tocPosition.start.range[0] - 1)); }
     data.push(wrappedToc);
-    if (!tocPosition.existing) { data.push(''); }
+    if (!tocPosition.existing && hasBody) { data.push(''); }
     data.push(content.slice(tocPosition.end.range[1] + (tocPosition.existing ? 1 : 0)));
   }
   return { transformed : transformed, data : data.join('\n'), toc: toc, wrappedToc: wrappedToc };

--- a/test/transform.js
+++ b/test/transform.js
@@ -897,10 +897,9 @@ test('\nhandles an empty document', function (t) {
         '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
         '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
         '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
-        '',
         ''
       ]
-    , 'generates correct toc for empty doc'
+    , 'generates correct document with toc for empty doc'
   )
 
   t.end()

--- a/test/transform.js
+++ b/test/transform.js
@@ -893,12 +893,12 @@ test('\nhandles an empty document', function (t) {
 
   t.same(
       res.data.split('\n')
-    , [ '',
-        '- [Hello, world!](#hello-world)',
-        '  - [Installation](#installation)',
-        '  - [API](#api)',
-        '  - [License](#license)',
-        '' ]
+    , [ 
+        '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+        '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+        '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+        ''
+      ]
     , 'generates correct toc for empty doc'
   )
 

--- a/test/transform.js
+++ b/test/transform.js
@@ -897,6 +897,7 @@ test('\nhandles an empty document', function (t) {
         '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
         '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
         '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+        '',
         ''
       ]
     , 'generates correct toc for empty doc'

--- a/test/transform.js
+++ b/test/transform.js
@@ -887,3 +887,20 @@ test('\nignores the hX which is in the content on or a different line', function
 
   t.end()
 })
+
+test('\nhandles an empty document', function (t) {
+  var res = transform('');
+
+  t.same(
+      res.data.split('\n')
+    , [ '',
+        '- [Hello, world!](#hello-world)',
+        '  - [Installation](#installation)',
+        '  - [API](#api)',
+        '  - [License](#license)',
+        '' ]
+    , 'generates correct toc for empty doc'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
This adds a test for handling empty files.

The lib change ensures that for new files we are only adding a blank line after the toc placeholder if there is content to follow.