### PR TITLE
chore: refactor recursive search for markdown files

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -21,13 +21,13 @@ function findRec(paths, syntax) {
     for (var fileInfo of fileInfos) {
       var fullPath = path.join(currentPath, fileInfo.name);
 
-      if (entry.isDirectory()) {
+      if (fileInfo.isDirectory()) {
         if (!ignoredDirs.includes(fileInfo.name)) {
           stack.push(fullPath);
         }
       }
 
-      if (entry.isFile()) {
+      if (fileInfo.isFile()) {
         if (allowedExts.includes(path.extname(fileInfo.name))) {
           markdownFiles.push({
             path: fullPath,

--- a/lib/file.js
+++ b/lib/file.js
@@ -8,30 +8,48 @@ var extensions = {
   md: ['.md', '.markdown'],
 };
 
-function findRec(currentPath, syntax) {
-  var fileInfos = fs.readdirSync(currentPath, { withFileTypes: true });
-  var markdownFiles = fileInfos.filter(x =>
-      x.isFile() && (extensions[syntax] || []).includes(path.extname(x.name))
-    )
-    .map(x => ({
-      path: path.join(currentPath, x.name),
-      name: x.name
-    }));
-  var markdownsInSubdirs = fileInfos.filter(x =>
-      x.isDirectory() && !ignoredDirs.includes(x.name)
-    )
-    .map(d => findRec(path.join(currentPath, d.name), syntax));
+function findRec(paths, syntax) {
+  var allowedExts = extensions[syntax] || [];
+  var results = [];
+  var stack = paths;
 
-  if (markdownFiles.length > 0)
-    log.debug('\nFound %s in "%s"', markdownFiles.map(f => f.name).join(', '), currentPath);
-  else
-    log.trace('\nFound nothing in "%s"', currentPath);
+  while (stack.length > 0) {
+    var markdownFiles = [];
+    var currentPath = stack.pop();
+    var fileInfos = fs.readdirSync(currentPath, { withFileTypes: true });
 
-  return markdownFiles.concat(markdownsInSubdirs).flat();
+    for (var fileInfo of fileInfos) {
+      var fullPath = path.join(currentPath, fileInfo.name);
+
+      if (entry.isDirectory()) {
+        if (!ignoredDirs.includes(fileInfo.name)) {
+          stack.push(fullPath);
+        }
+      }
+
+      if (entry.isFile()) {
+        if (allowedExts.includes(path.extname(fileInfo.name))) {
+          markdownFiles.push({
+            path: fullPath,
+            name: fileInfo.name
+          });
+        }
+      }
+    }
+
+    if (markdownFiles.length > 0)
+      log.debug('\nFound %s in "%s"', markdownFiles.map(f => f.name).join(', '), currentPath);
+    else
+      log.trace('\nFound nothing in "%s"', currentPath);
+
+    results.push(...markdownFiles);
+  }
+
+  return results;
 }
 
 // Finds all markdown files in given directory and its sub-directories
 // @param {String  } dir - the absolute directory to search in
 exports.findMarkdownFiles = function (dir, syntax) {
-  return findRec(dir, syntax);
+  return findRec([dir], syntax);
 };

--- a/lib/file.js
+++ b/lib/file.js
@@ -9,7 +9,7 @@ var extensions = {
 };
 
 function findRec(currentPath, syntax) {
-  var fileInfos = fs.readdirSync(currentPath, { withFileTypes: true }),
+  var fileInfos = fs.readdirSync(currentPath, { withFileTypes: true });
   var markdownFiles = fileInfos.filter(x =>
       x.isFile() && (extensions[syntax] || []).includes(path.extname(x.name))
     )

--- a/lib/file.js
+++ b/lib/file.js
@@ -8,49 +8,26 @@ var extensions = {
   md: ['.md', '.markdown'],
 };
 
-function separateFilesAndDirs(fileInfos, syntax) {
-  return {
-    directories: fileInfos.filter(x =>
-      x.isDirectory() && !ignoredDirs.includes(x.name)
-    ),
-    markdownFiles: fileInfos.filter(x =>
-      x.isFile() && (extensions[syntax] || []).includes(path.extname(x.name))
-    ),
-  };
-}
-
 function findRec(currentPath, syntax) {
-  function getStat(entry) {
-    var target = path.join(currentPath, entry),
-      stat = fs.statSync(target);
+  var fileInfos = fs.readdirSync(currentPath, { withFileTypes: true }),
+  var markdownFiles = fileInfos.filter(x =>
+      x.isFile() && (extensions[syntax] || []).includes(path.extname(x.name))
+    )
+    .map(x => ({
+      path: path.join(currentPath, x.name),
+      name: x.name
+    }));
+  var markdownsInSubdirs = fileInfos.filter(x =>
+      x.isDirectory() && !ignoredDirs.includes(x.name)
+    )
+    .map(d => findRec(path.join(currentPath, d.name), syntax));
 
-    return Object.assign(stat, {
-      name: entry,
-      path: target,
-    });
-  }
+  if (markdownFiles.length > 0)
+    log.debug('\nFound %s in "%s"', markdownFiles.map(f => f.name).join(', '), currentPath);
+  else
+    log.trace('\nFound nothing in "%s"', currentPath);
 
-  function process (fileInfos) {
-    var res = separateFilesAndDirs(fileInfos, syntax);
-    var tgts = res.directories.map(d => d.path);
-
-    if (res.markdownFiles.length > 0)
-      log.debug('\nFound %s in "%s"', res.markdownFiles.map(f => f.name).join(', '), currentPath);
-    else
-      log.trace('\nFound nothing in "%s"', currentPath);
-
-    return {
-      markdownFiles: res.markdownFiles,
-      subdirs: tgts
-    };
-  }
-
-  var stats = fs.readdirSync(currentPath).map(getStat),
-    res = process(stats),
-    markdownsInSubdirs = res.subdirs.map((subdir)=> findRec(subdir, syntax)),
-    allMarkdownsHereAndSub = res.markdownFiles.concat(markdownsInSubdirs);
-
-  return allMarkdownsHereAndSub.flat();
+  return markdownFiles.concat(markdownsInSubdirs).flat();
 }
 
 // Finds all markdown files in given directory and its sub-directories

--- a/lib/file.js
+++ b/lib/file.js
@@ -21,19 +21,15 @@ function findRec(paths, syntax) {
     for (var fileInfo of fileInfos) {
       var fullPath = path.join(currentPath, fileInfo.name);
 
-      if (fileInfo.isDirectory()) {
-        if (!ignoredDirs.includes(fileInfo.name)) {
-          stack.push(fullPath);
-        }
+      if (fileInfo.isDirectory() && !ignoredDirs.includes(fileInfo.name)) {
+        stack.push(fullPath);
       }
 
-      if (fileInfo.isFile()) {
-        if (allowedExts.includes(path.extname(fileInfo.name))) {
-          markdownFiles.push({
-            path: fullPath,
-            name: fileInfo.name
-          });
-        }
+      if (fileInfo.isFile() && allowedExts.includes(path.extname(fileInfo.name)) {
+        markdownFiles.push({
+          path: fullPath,
+          name: fileInfo.name
+        });
       }
     }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -25,7 +25,7 @@ function findRec(paths, syntax) {
         stack.push(fullPath);
       }
 
-      if (fileInfo.isFile() && allowedExts.includes(path.extname(fileInfo.name)) {
+      if (fileInfo.isFile() && allowedExts.includes(path.extname(fileInfo.name))) {
         markdownFiles.push({
           path: fullPath,
           name: fileInfo.name

--- a/lib/file.js
+++ b/lib/file.js
@@ -11,7 +11,7 @@ var extensions = {
 function findRec(paths, syntax) {
   var allowedExts = extensions[syntax] || [];
   var results = [];
-  var stack = paths;
+  var stack = [...paths];
 
   while (stack.length > 0) {
     var markdownFiles = [];


### PR DESCRIPTION
Eliminate the statSync to optimise performance as that is often a costly operation which we do not need to be calling.

Overall optimisation of the get recursive ensuring streamlined operations and reduction in variable usage/allocations.