### PR TITLE
feat: Add ability for different symbol per level

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ by github or other sites via a command line flag.
   - [Min. Document Lines](#min-document-lines)
   - [Pad table of contents title](#pad-table-of-contents-title)
   - [Indentation Style](#indentation-style)
+  - [Item Symbol](#item-symbol)
   - [TOC Pragma style](#toc-pragma-style)
 - [Usage](#usage)
   - [Configuring logging level](#configuring-logging-level)
@@ -152,6 +153,12 @@ In all cases there will be padding present after the title due to the toc items 
 Use the `--toc-items-indentation-width` option to customise the indentation width e.g. `doctoc --toc-items-indentation-width 4 .` will set the width to 4.
 
 By default, a width of 4 will be used if mode is gitlab or bitbucket, otherwise 2 will be used.
+
+### Item Symbol
+
+Use the `--entry-prefix` option to configure the symbol used in unordered toc e.g, `doctoc --entry-prefix * .` to use the `*` rather than the default which is `-`.
+
+This option supports also customising each level of the list which can be done by using a comma seperated list of symbols ie `doctoc --entry-prefix -,*+ .`.
 
 ### TOC Pragma style
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ By default, a width of 4 will be used if mode is gitlab or bitbucket, otherwise 
 
 ### Item Symbol
 
-Use the `--entry-prefix` option to configure the symbol used in unordered toc e.g, `doctoc --entry-prefix * .` to use the `*` rather than the default which is `-`.
+Use the `--entry-prefix` option to configure the symbol used in unordered toc, e.g., `doctoc --entry-prefix * .` to use the `*` rather than the default, which is `-`.
 
-This option supports also customising each level of the list which can be done by using a comma seperated list of symbols ie `doctoc --entry-prefix -,*+ .`.
+This option also supports customising each level of the list, which can be done by using a comma separated list of symbols, i.e. `doctoc --entry-prefix -,*,+ .`.
 
 ### TOC Pragma style
 

--- a/doctoc.js
+++ b/doctoc.js
@@ -132,7 +132,9 @@ for (var key in modes) {
 
 var title = argv.t || argv.title;
 var notitle = argv.T || argv.notitle;
-var entryPrefix = argv.entryprefix || '-';
+var entryPrefix = argv.entryprefix?.trim().replace(' ', '');
+if (entryPrefix?.endsWith(',') || entryPrefix?.includes(',,')) { log.error('Invalid entry prefix: ' + entryPrefix), printUsageAndExit(true); }
+else if(!entryPrefix) { entryPrefix = '-'; }
 var minTocItems = argv.mintocitems || 1;
 if (minTocItems && (isNaN(minTocItems) || minTocItems <= 0)) { log.error('Min. TOC items specified is not a positive number: ' + minTocItems), printUsageAndExit(true); }
 var processAll = argv.all;

--- a/doctoc.js
+++ b/doctoc.js
@@ -132,8 +132,8 @@ for (var key in modes) {
 
 var title = argv.t || argv.title;
 var notitle = argv.T || argv.notitle;
-var entryPrefix = argv.entryprefix?.trim().replace(' ', '');
-if (entryPrefix?.endsWith(',') || entryPrefix?.includes(',,')) { log.error('Invalid entry prefix: ' + entryPrefix), printUsageAndExit(true); }
+var entryPrefix = argv.entryprefix?.trim().replaceAll(' ', '');
+if (entryPrefix?.endsWith(',') || entryPrefix?.startsWith(',') || entryPrefix?.includes(',,')) { log.error('Invalid entry prefix: ' + entryPrefix), printUsageAndExit(true); }
 else if(!entryPrefix) { entryPrefix = '-'; }
 var minTocItems = argv.mintocitems || 1;
 if (minTocItems && (isNaN(minTocItems) || minTocItems <= 0)) { log.error('Min. TOC items specified is not a positive number: ' + minTocItems), printUsageAndExit(true); }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -186,7 +186,8 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };
 
   mode = mode || "github.com";
-  var itemSymbols = entryPrefix.split(',') || ["-"];
+  entryPrefix = entryPrefix || "-";
+  var itemSymbols = entryPrefix.split(',');
   minHeaderLevel = minHeaderLevel || 1;
 
   if (isNaN(minTocItems) || minTocItems < 1){

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -178,7 +178,12 @@ function detectLineEnding(content, defaultEol) {
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
+  options ??= {};
+  options.toc ??= {};
+  options.toc.items ??= {};
+
   syntax = syntax || "md";
+  options.toc.items.symbols ??= String(entryPrefix || "-").split(',');
   var eol = '\n';
   eol = detectLineEnding(content, eol);
   var skipTag = contentGenerator.skipTag(syntax) + eol;
@@ -186,8 +191,6 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };
 
   mode = mode || "github.com";
-  entryPrefix = entryPrefix || "-";
-  var itemSymbols = entryPrefix.split(',');
   minHeaderLevel = minHeaderLevel || 1;
 
   if (isNaN(minTocItems) || minTocItems < 1){
@@ -275,12 +278,14 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (padTitle && inferredTitle) { tocLines.push(''); }
     if (inferredTitle) { tocLines.push(inferredTitle); }
     tocLines.push('');
-    var symbolQty = itemSymbols.length;
+    var symbolQty = options.toc.items.symbols.length;
 
     tocLines.push(...allHeaders
         .map(function (x) {
-          var level = x.rank - lowestRank
-          return indentation.repeat(level * indentationWidth) + itemSymbols[level % symbolQty].trim() + ' ' + x.anchor;
+          var level = x.rank - lowestRank;
+          var symbol;
+          symbol = options.toc.items.symbols[level % symbolQty].trim();
+          return indentation.repeat(level * indentationWidth) + symbol + ' ' + x.anchor;
         }));
 
     tocLines.push('');

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -186,7 +186,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (index === 0 || (index >= 0 && content[index-1] === eol)) return { transformed: false };
 
   mode = mode || "github.com";
-  entryPrefix = entryPrefix || "-";
+  var itemSymbols = entryPrefix.split(',') || ["-"];
   minHeaderLevel = minHeaderLevel || 1;
 
   if (isNaN(minTocItems) || minTocItems < 1){
@@ -274,10 +274,12 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (padTitle && inferredTitle) { tocLines.push(''); }
     if (inferredTitle) { tocLines.push(inferredTitle); }
     tocLines.push('');
+    var symbolQty = itemSymbols.length;
 
     tocLines.push(...allHeaders
         .map(function (x) {
-          return indentation.repeat((x.rank - lowestRank) * indentationWidth) + entryPrefix + ' ' + x.anchor;
+          var level = x.rank - lowestRank
+          return indentation.repeat(level * indentationWidth) + itemSymbols[level % symbolQty].trim() + ' ' + x.anchor;
         }));
 
     tocLines.push('');

--- a/test/transform-toc-items.js
+++ b/test/transform-toc-items.js
@@ -1,0 +1,34 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test,
+  transform = require('../lib/transform');
+
+test('transforming using a collection of symbols', function (t) {
+  var md = [ 
+      '# My Module',
+      'Some text here',
+      '## API',
+      '### Method One',
+      'works like this',
+      '### Method Two',
+      '#### Main Usage',
+      'some main usage here',
+    ].join('\n');
+  var contents = [
+      '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+      '',
+      '- [My Module](#my-module)',
+      '  * [API](#api)',
+      '    + [Method One](#method-one)',
+      '    + [Method Two](#method-two)',
+      '      - [Main Usage](#main-usage)',
+      ''
+    ].join('\n');
+
+  var res = transform(md, undefined, undefined, undefined, undefined, undefined, undefined, '-,*,+');
+
+  t.ok(res.transformed, 'transforms it');
+  t.same(res.toc, contents, 'generates correct toc contents');
+  t.end();
+});

--- a/test/transform.js
+++ b/test/transform.js
@@ -992,32 +992,6 @@ check(
     , 'some main usage here'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '- [My Module](#my-module)\n'
-    , '  * [API](#api)\n'
-    , '    + [Method One](#method-one)\n'
-    , '    + [Method Two](#method-two)\n'
-    , '      - [Main Usage](#main-usage)\n\n\n'
-    ].join('')
-  , undefined
-  , undefined
-  , undefined
-  , undefined
-  , undefined
-  , undefined
-  , '-,*,+' // pass a collection as the prefix for toc entries
-)
-
-check(
-    [ '# My Module'
-    , 'Some text here'
-    , '## API'
-    , '### Method One'
-    , 'works like this'
-    , '### Method Two'
-    , '#### Main Usage'
-    , 'some main usage here'
-    ].join('\n')
-  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
     , '1. [My Module](#my-module)\n'
     ,   '  1. [API](#api)\n'
     ,     '    1. [Method One](#method-one)\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -992,6 +992,32 @@ check(
     , 'some main usage here'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [My Module](#my-module)\n'
+    , '  * [API](#api)\n'
+    , '    + [Method One](#method-one)\n'
+    , '    + [Method Two](#method-two)\n'
+    , '      - [Main Usage](#main-usage)\n\n\n'
+    ].join('')
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , '-,*,+' // pass a collection as the prefix for toc entries
+)
+
+check(
+    [ '# My Module'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this'
+    , '### Method Two'
+    , '#### Main Usage'
+    , 'some main usage here'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
     , '1. [My Module](#my-module)\n'
     ,   '  1. [API](#api)\n'
     ,     '    1. [Method One](#method-one)\n'


### PR DESCRIPTION
Progresses #263

This enables the symbol used in unordered toc to differ on a per level basis.

This further assists with adoption as the tool can now work with whatever list symbol/s is used in the doc