### PR TITLE
feat: Add support for ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Use the `--toc-list-format` option to control the format of the toc list, i.e. `
 The supported options are:
 
  - `ordered`: the list items are numbered rather than using a symbol with the style controlled via the `--toc-list-style` option.
- - `unordered`: the list items use a symnol. This is the default behaviour.
+ - `unordered`: the list items use a symbol. This is the default behaviour.
 
 ##### Style
 
@@ -277,7 +277,7 @@ The supported options are:
  - `lowercase`: the list items are identified using lowercase letters ie `a.c.a`.
  - `number`: the list items are identified using numbers letters ie `1.3.1`. This is the default behaviour.
  - `roman`: the list items are identified using roman numerals ie `I.III.I`.
- - `uppercase`: the list items are identified using lowercase letters ie `A.C.A`.
+ - `uppercase`: the list items are identified using uppercase letters ie `A.C.A`.
 
 #### TOC Items
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Use the `--toc-list-style` option to control the style of the ordered toc list, 
 The supported options are:
 
  - `lowercase`: the list items are identified using lowercase letters ie `a.c.a`.
- - `number`: the list items are identified using numbers letters ie `1.3.1`. This is the default behaviour.
+ - `number`: the list items are identified using numbers ie `1.3.1`. This is the default behaviour.
  - `roman`: the list items are identified using roman numerals ie `I.III.I`.
  - `uppercase`: the list items are identified using uppercase letters ie `A.C.A`.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ by github or other sites via a command line flag.
     - [General](#general)
     - [Header](#header)
     - [Title](#title)
-    - [List Options](#list-options)
+    - [List](#list)
     - [TOC Items](#toc-items)
     - [Footer](#footer)
 - [Usage](#usage)
@@ -234,7 +234,7 @@ By default,
 
 In all cases there will be padding present after the title due to the toc items always having padding before the list of items.
 
-#### List Options
+#### List
 
 ##### Min. Length
 
@@ -243,6 +243,26 @@ Use the `--mintocitems` option to specify the minimum items required to be in a 
 By default,
 
 - The min items is set to 1
+
+##### Format
+
+Use the `--toc-list-format` option to control the format of the toc list, i.e. `doctoc --toc-list-format unordered`. 
+
+The supported options are:
+
+ - `ordered`: the list items are numbered rather than using a symbol with the style controlled via the `--toc-list-style` option.
+ - `unordered`: the list items use a symnol. This is the default behaviour.
+
+##### Style
+
+Use the `--toc-list-style` option to control the style of the ordered toc list, i.e. `doctoc --toc-list-style roman`. 
+
+The supported options are:
+
+ - `lowercase`: the list items are identified using lowercase letters ie `a.c.a`.
+ - `number`: the list items are identified using numbers letters ie `1.3.1`. This is the default behaviour.
+ - `roman`: the list items are identified using roman numerals ie `I.III.I`.
+ - `uppercase`: the list items are identified using lowercase letters ie `A.C.A`.
 
 #### TOC Items
 

--- a/doctoc.js
+++ b/doctoc.js
@@ -172,7 +172,6 @@ var ordered = format === 'ordered';
 var style = argv['toc-list-style'];
 if (ordered && style && style != 'number' && style != 'uppercase' && style != 'lowercase' && style != 'roman') { log.error('TOC List style: ' + style + ' is not valid.'), printUsageAndExit(true); }
 else if (!ordered && style) { log.error('TOC List style: ' + style + ' should not be specified for unordered list.'), printUsageAndExit(true); }
-else if (ordered && style) { log.error('TOC List style: ' + style + ' should not be specified for unordered list.'), printUsageAndExit(true); }
 
 var entryPrefix = argv.entryprefix?.trim().replaceAll(' ', '');
 if (entryPrefix?.endsWith(',') || entryPrefix?.startsWith(',') || entryPrefix?.includes(',,')) { log.error('Invalid entry prefix: ' + entryPrefix), printUsageAndExit(true); }

--- a/doctoc.js
+++ b/doctoc.js
@@ -132,9 +132,6 @@ for (var key in modes) {
 
 var title = argv.t || argv.title;
 var notitle = argv.T || argv.notitle;
-var entryPrefix = argv.entryprefix?.trim().replaceAll(' ', '');
-if (entryPrefix?.endsWith(',') || entryPrefix?.startsWith(',') || entryPrefix?.includes(',,')) { log.error('Invalid entry prefix: ' + entryPrefix), printUsageAndExit(true); }
-else if(!entryPrefix) { entryPrefix = '-'; }
 var minTocItems = argv.mintocitems || 1;
 if (minTocItems && (isNaN(minTocItems) || minTocItems <= 0)) { log.error('Min. TOC items specified is not a positive number: ' + minTocItems), printUsageAndExit(true); }
 var processAll = argv.all;
@@ -173,8 +170,14 @@ var format = argv['toc-list-format'] || 'unordered';
 if (format && format != 'ordered' && format != 'unordered') { log.error('TOC List format: ' + format + ' is not valid'), printUsageAndExit(true); }
 var ordered = format === 'ordered';
 var style = argv['toc-list-style'];
-var symbol = entryPrefix.split(',') || ['-'];
-if (ordered && style && style != 'number' && style != 'uppercase' && style != 'lowercase' && style != 'roman') { log.error('TOC List style: ' + style + ' is not valid'), printUsageAndExit(true); }
+if (ordered && style && style != 'number' && style != 'uppercase' && style != 'lowercase' && style != 'roman') { log.error('TOC List style: ' + style + ' is not valid.'), printUsageAndExit(true); }
+else if (!ordered && style) { log.error('TOC List style: ' + style + ' should not be specified for unordered list.'), printUsageAndExit(true); }
+else if (ordered && style) { log.error('TOC List style: ' + style + ' should not be specified for unordered list.'), printUsageAndExit(true); }
+
+var entryPrefix = argv.entryprefix?.trim().replaceAll(' ', '');
+if (entryPrefix?.endsWith(',') || entryPrefix?.startsWith(',') || entryPrefix?.includes(',,')) { log.error('Invalid entry prefix: ' + entryPrefix), printUsageAndExit(true); }
+else if (ordered && entryPrefix) { log.error('TOC List item prefix: ' + entryPrefix + ' should not be specified for ordered list.'), printUsageAndExit(true); }
+else if(!entryPrefix) { entryPrefix = '-'; }
 
 var options = {
   document: {
@@ -197,8 +200,7 @@ var options = {
       indentation: {
         width: indentWidth,
         style: indentStyle,
-      },
-      symbol: !ordered ? symbol : undefined
+      }
     },
     location: location,
     title: {

--- a/doctoc.js
+++ b/doctoc.js
@@ -73,7 +73,7 @@ function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocIte
 function printUsageAndExit(isErr) {
   var outputFunc = isErr ? log.error : log.info;
 
-  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--minlevel level] [--mintocitems qty] [--toc-location location] [--toc-pragma-style style] [--toc-header-content content] [--toc-footer-content content] [--toc-items-indentation-width width] [--all] [--loglevel level] [--update-only] [--syntax (' + supportedSyntaxes.join("|") + ')] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
+  outputFunc('Usage: doctoc [mode] [--entryprefix prefix] [--notitle | --title title] [--maxlevel level] [--minlevel level] [--mintocitems qty] [--toc-location location] [--toc-pragma-style style] [--toc-header-content content] [--toc-footer-content content] [--toc-list-format format] [--toc-list-style style] [--toc-items-indentation-width width] [--all] [--loglevel level] [--update-only] [--syntax (' + supportedSyntaxes.join("|") + ')] <path> (where path is some path to a directory (e.g., .) or a file (e.g., README.md))');
   outputFunc('\nAvailable modes are:');
   for (var key in modes) {
     outputFunc("  --%s\t%s", key, modes[key]);
@@ -97,7 +97,7 @@ var mode = modes["github"];
 var argv = minimist(process.argv.slice(2),
     {
       boolean: [ 'h', 'help', 'T', 'notitle', 's', 'stdout', 'all' , 'u', 'update-only', 'd', 'dryrun'].concat(Object.keys(modes)),
-      string: [ 'title', 't', 'maxlevel', 'm', 'minlevel', 'entryprefix', 'syntax', 'mintocitems', 'toc-location', 'toc-title-padding-before', 'toc-header-content', 'toc-footer-content', 'toc-pragma-style', 'toc-items-indentation-width', 'document-lines-min', 'l', 'loglevel' ],
+      string: [ 'title', 't', 'maxlevel', 'm', 'minlevel', 'entryprefix', 'syntax', 'mintocitems', 'toc-location', 'toc-title-padding-before', 'toc-header-content', 'toc-footer-content', 'toc-pragma-style', 'toc-list-format', 'toc-list-style', 'toc-items-indentation-width', 'document-lines-min', 'l', 'loglevel' ],
       unknown: function(a) { return (a[0] == '-' ? (console.error('Unknown option(s): ' + a), printUsageAndExit(true)) : true); }
     });
 
@@ -166,6 +166,13 @@ if (isNaN(minLines)) { log.error('Document min lines: ' + minLines + ' is not a 
 var location = argv['toc-location'] || 'top';
 if (location != 'top' && location != 'before') { log.error('Location specified is not valid: ' + location), printUsageAndExit(true); }
 
+var format = argv['toc-list-format'] || 'unordered';
+if (format && format != 'ordered' && format != 'unordered') { log.error('TOC List format: ' + format + ' is not valid'), printUsageAndExit(true); }
+var ordered = format === 'ordered';
+var style = argv['toc-list-style'];
+var symbol = entryPrefix.split(',') || ['-'];
+if (ordered && style && style != 'number' && style != 'uppercase' && style != 'lowercase' && style != 'roman') { log.error('TOC List style: ' + style + ' is not valid'), printUsageAndExit(true); }
+
 var options = {
   document: {
     lines: {
@@ -179,10 +186,15 @@ var options = {
     header: {
       content: argv['toc-header-content'],
     },
+    list: {
+      format: format,
+      style: ordered ? style || 'number' : undefined
+    },
     items: {
-      indentation:{
+      indentation: {
         width: indentWidth,
-      }
+      },
+      symbol: !ordered ? symbol : undefined
     },
     location: location,
     title: {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -5,7 +5,7 @@ var anchor = require("anchor-markdown-header"),
   contentGenerator = require("./content-generation"),
   md = require("@textlint/markdown-to-ast");
 
-const ROMMAN_NUMERALS = {
+const ROMAN_NUMERALS = {
   THOUSANDS: ["", "M", "MM", "MMM"],
   HUNDREDS: ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"],
   TENS: ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"],
@@ -216,9 +216,9 @@ function determineSegment(style, num) {
   }
   else if (style === 'roman') {
     var numeral = ROMMAN_NUMERALS.THOUSANDS[(num/1000)|0] +
-      ROMMAN_NUMERALS.HUNDREDS[(num%1000/100)|0] +
-      ROMMAN_NUMERALS.TENS[(num%100/10)|0] +
-      ROMMAN_NUMERALS.ONES[num%10];
+      ROMAN_NUMERALS.HUNDREDS[(num%1000/100)|0] +
+      ROMAN_NUMERALS.TENS[(num%100/10)|0] +
+      ROMAN_NUMERALS.ONES[num%10];
 
     return numeral;
   }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -5,6 +5,11 @@ var anchor = require("anchor-markdown-header"),
   contentGenerator = require("./content-generation"),
   md = require("@textlint/markdown-to-ast");
 
+const M = ["", "M", "MM", "MMM"];
+const C = ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"];
+const X = ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"];
+const I = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"];
+
 function matchesStart(syntax) {
   var commentEscapedStart = contentGenerator.escapedStartTag(syntax);
   return function(line){
@@ -194,6 +199,30 @@ function detectLineEnding(content, defaultEol) {
   return eol || defaultEol;
 }
 
+function determineSegment(style, num) {
+  if (style === 'lowercase' || style === 'uppercase') {
+    let columnName = '';
+    const baseCharCode = style === 'uppercase' ? 65 : 97; // 'A' or 'a'
+
+    while (num > 0) {
+        num--;
+        const remainder = num % 26;
+        columnName = String.fromCharCode(baseCharCode + remainder) + columnName;
+        num = Math.floor(num / 26);
+    }
+    return columnName;
+  }
+  else if (style === 'roman') {
+    var numeral = M[(num/1000)|0] +
+      C[(num%1000/100)|0] +
+      X[(num%100/10)|0] +
+      I[num%10];
+
+    return numeral;
+  }
+  return undefined;
+}
+
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   options ??= {};
   options.toc ??= {};
@@ -213,6 +242,11 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (isNaN(minTocItems) || minTocItems < 1){
     minTocItems = 1;
   }
+  
+  if (!options) { options = { }; }
+  if (!options.toc) { options.toc = { }; }
+  if (!options.toc.list) { options.toc.list = { format: 'unordered' }; }
+  if (!options.toc.items) { options.toc.items = { symbols: entryPrefix.split(',') }; }
 
   var padTitle = options?.toc?.title?.padding?.before > 0;
   if (options?.toc?.title?.padding?.before === undefined){
@@ -315,54 +349,33 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (inferredTitle) { tocLines.push(inferredTitle); }
     tocLines.push('');
     var symbolQty = options.toc.items.symbols.length;
-    
-    const M = ["", "M", "MM", "MMM"];
-    const C = ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"];
-    const X = ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"];
-    const I = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"];
 
     var count = [];
     var symbols = [];
-    var numeric = entryPrefix == 'number';
     tocLines.push(...allHeaders
         .map(function (x) {
           var level = x.rank - lowestRank;
           var symbol;
-          var index = (count[level] || 0) + 1;
-          count[level] = index;
-          if (index > 1) {
-            count = count.slice(0, level + 1);
-            symbols = symbols.slice(0, level + 1);
+          if (options.toc.list.format == 'ordered') {
+            var index = (count[level] || 0) + 1;
+            count[level] = index;
+            if (index > 1) {
+              count = count.slice(0, level + 1);
+              symbols = symbols.slice(0, level + 1);
+            }
           }
-          if (entryPrefix == 'number') {
+          if (options.toc.list.format == 'unordered') {
+            symbol = options.toc.items.symbols[level % symbolQty].trim();
+          }
+          else if (options.toc.list.style === 'number') {
             symbol = count.join('.') + '.';
           }
-          else if (entryPrefix == 'lowercase' || entryPrefix == 'uppercase') {
-            let columnName = '';
-            const baseCharCode = entryPrefix == 'uppercase' ? 65 : 97; // 'A' or 'a'
-            
-            while (num > 0) {
-              num--;
-              const remainder = num % 26;
-              columnName = String.fromCharCode(baseCharCode + remainder) + columnName;
-              num = Math.floor(num / 26);
-            }
-            symbols[level] = columnName;
-            symbol = symbols.join('.') + '.';
-          }
-          else if () {
-            var numeral = M[(n/1000)|0] +
-              C[(n%1000/100)|0] +
-              X[(n%100/10)|0] +
-              I[n%10];
-
-            symbols[level] = numeral;
-            symbol = symbols.join('.') + '.';
-          }
           else {
-            symbol = entryPrefix;
+            let segment = determineSegment(options.toc.list.style, count[level]);
+            symbols[level] = segment;
+            symbol = symbols.join('.') + '.';
           }
-          return indentation.repeat((x.rank - lowestRank) * indentationWidth) + symbol + ' ' + x.anchor;
+          return indentation.repeat(level * indentationWidth) + symbol + ' ' + x.anchor;
         }));
 
     tocLines.push('');

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -215,7 +215,7 @@ function determineSegment(style, num) {
     return columnName;
   }
   else if (style === 'roman') {
-    var numeral = ROMMAN_NUMERALS.THOUSANDS[(num/1000)|0] +
+    var numeral = ROMAN_NUMERALS.THOUSANDS[(num/1000)|0] +
       ROMAN_NUMERALS.HUNDREDS[(num%1000/100)|0] +
       ROMAN_NUMERALS.TENS[(num%100/10)|0] +
       ROMAN_NUMERALS.ONES[num%10];

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -321,9 +321,10 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     tocLines.push(...allHeaders
         .map(function (x) {
           var level = x.rank - lowestRank;
-          if (count[level]) {
-            count[level]++;
-            count = count.slice(level + 1);
+          var previous = count[level];
+          if (previous) {
+            count[level] = previous + 1;
+            count = count.slice(0, level + 1);
           }
           else {
             count[level] = 1;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -316,11 +316,20 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     tocLines.push('');
     var symbolQty = options.toc.items.symbols.length;
 
+    var count = [];
+    var numeric = entryPrefix == 'number';
     tocLines.push(...allHeaders
         .map(function (x) {
           var level = x.rank - lowestRank;
+          if (count[level]) {
+            count[level]++;
+            count = count.slice(level + 1);
+          }
+          else {
+            count[level] = 1;
+          }
           var symbol;
-          symbol = options.toc.items.symbols[level % symbolQty].trim();
+          symbol = numeric ? count.join('.') : options.toc.items.symbols[level % symbolQty].trim();
           return indentation.repeat(level * indentationWidth) + symbol + ' ' + x.anchor;
         }));
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -330,7 +330,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
             count[level] = 1;
           }
           var symbol;
-          symbol = numeric ? count.join('.') : options.toc.items.symbols[level % symbolQty].trim();
+          symbol = numeric ? count.join('.') + '.': options.toc.items.symbols[level % symbolQty].trim();
           return indentation.repeat(level * indentationWidth) + symbol + ' ' + x.anchor;
         }));
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -5,10 +5,12 @@ var anchor = require("anchor-markdown-header"),
   contentGenerator = require("./content-generation"),
   md = require("@textlint/markdown-to-ast");
 
-const M = ["", "M", "MM", "MMM"];
-const C = ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"];
-const X = ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"];
-const I = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"];
+const ROMMAN_NUMERALS = {
+  THOUSANDS: ["", "M", "MM", "MMM"],
+  HUNDREDS: ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"],
+  TENS: ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"],
+  ONES: ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"]
+};
 
 function matchesStart(syntax) {
   var commentEscapedStart = contentGenerator.escapedStartTag(syntax);
@@ -213,10 +215,10 @@ function determineSegment(style, num) {
     return columnName;
   }
   else if (style === 'roman') {
-    var numeral = M[(num/1000)|0] +
-      C[(num%1000/100)|0] +
-      X[(num%100/10)|0] +
-      I[num%10];
+    var numeral = ROMMAN_NUMERALS.THOUSANDS[(num/1000)|0] +
+      ROMMAN_NUMERALS.HUNDREDS[(num%1000/100)|0] +
+      ROMMAN_NUMERALS.TENS[(num%100/10)|0] +
+      ROMMAN_NUMERALS.ONES[num%10];
 
     return numeral;
   }
@@ -228,13 +230,17 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   options.toc ??= {};
   options.toc.items ??= {};
   options.toc.items.indentation ??= {};
+  options.toc.list ??= {};
 
   syntax = syntax || "md";
   options.toc.items.indentation.style ??= 'space';
   options.toc.items.indentation.width ??= options.toc.items.indentation.style === 'tab' ? 1 : (
     mode === 'bitbucket.org' || mode === 'gitlab.com' ? 4 : 2
   );
-  options.toc.items.symbols ??= String(entryPrefix || '-').split(',');
+  options.toc.list.format ??= 'unordered';
+  var ordered = options.toc.list.format === 'ordered';
+  options.toc.items.symbols ??= ordered ? undefined : String(entryPrefix || '-').split(',');
+  options.toc.list.style ??= ordered ? 'number' : undefined
 
   var eol = '\n';
   eol = detectLineEnding(content, eol);
@@ -248,11 +254,6 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (isNaN(minTocItems) || minTocItems < 1){
     minTocItems = 1;
   }
-  
-  if (!options) { options = { }; }
-  if (!options.toc) { options.toc = { }; }
-  if (!options.toc.list) { options.toc.list = { format: 'unordered' }; }
-  if (!options.toc.items) { options.toc.items = { symbols: entryPrefix.split(',') }; }
 
   var padTitle = options?.toc?.title?.padding?.before > 0;
   if (options?.toc?.title?.padding?.before === undefined){
@@ -348,7 +349,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (padTitle && inferredTitle) { tocLines.push(''); }
     if (inferredTitle) { tocLines.push(inferredTitle); }
     tocLines.push('');
-    var symbolQty = options.toc.items.symbols.length;
+    var symbolQty = options.toc.items.symbols?.length || 1;
 
     var count = [];
     var symbols = [];
@@ -357,6 +358,9 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
           var level = x.rank - lowestRank;
           var symbol;
           if (options.toc.list.format == 'ordered') {
+            while (count.length < level) {
+              count.push(1);
+            }
             var index = (count[level] || 0) + 1;
             count[level] = index;
             if (index > 1) {
@@ -375,7 +379,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
             symbols[level] = segment;
             symbol = symbols.join('.') + '.';
           }
-          return indentation.repeat(level * indentationWidth) + symbol + ' ' + x.anchor;
+          return indentation.repeat(level * options.toc.items.indentation.width) + symbol + ' ' + x.anchor;
         }));
 
     tocLines.push('');

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -315,23 +315,54 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     if (inferredTitle) { tocLines.push(inferredTitle); }
     tocLines.push('');
     var symbolQty = options.toc.items.symbols.length;
+    
+    const M = ["", "M", "MM", "MMM"];
+    const C = ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"];
+    const X = ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"];
+    const I = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"];
 
     var count = [];
+    var symbols = [];
     var numeric = entryPrefix == 'number';
     tocLines.push(...allHeaders
         .map(function (x) {
           var level = x.rank - lowestRank;
-          var previous = count[level];
-          if (previous) {
-            count[level] = previous + 1;
+          var symbol;
+          var index = (count[level] || 0) + 1;
+          count[level] = index;
+          if (index > 1) {
             count = count.slice(0, level + 1);
+            symbols = symbols.slice(0, level + 1);
+          }
+          if (entryPrefix == 'number') {
+            symbol = count.join('.') + '.';
+          }
+          else if (entryPrefix == 'lowercase' || entryPrefix == 'uppercase') {
+            let columnName = '';
+            const baseCharCode = entryPrefix == 'uppercase' ? 65 : 97; // 'A' or 'a'
+            
+            while (num > 0) {
+              num--;
+              const remainder = num % 26;
+              columnName = String.fromCharCode(baseCharCode + remainder) + columnName;
+              num = Math.floor(num / 26);
+            }
+            symbols[level] = columnName;
+            symbol = symbols.join('.') + '.';
+          }
+          else if () {
+            var numeral = M[(n/1000)|0] +
+              C[(n%1000/100)|0] +
+              X[(n%100/10)|0] +
+              I[n%10];
+
+            symbols[level] = numeral;
+            symbol = symbols.join('.') + '.';
           }
           else {
-            count[level] = 1;
+            symbol = entryPrefix;
           }
-          var symbol;
-          symbol = numeric ? count.join('.') + '.': options.toc.items.symbols[level % symbolQty].trim();
-          return indentation.repeat(level * indentationWidth) + symbol + ' ' + x.anchor;
+          return indentation.repeat((x.rank - lowestRank) * indentationWidth) + symbol + ' ' + x.anchor;
         }));
 
     tocLines.push('');

--- a/test/fixtures/readme-formatting.md
+++ b/test/fixtures/readme-formatting.md
@@ -1,0 +1,15 @@
+# My Module
+
+Some text here
+
+## API
+
+### Method One
+
+works like this
+
+### Method Two
+
+#### Main Usage
+
+## Some More

--- a/test/transform-list.js
+++ b/test/transform-list.js
@@ -1,0 +1,126 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test,
+    fs = require('fs'),
+    transform = require('../lib/transform');
+    
+test('\nNumerical ToC ', function (t) {
+  var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
+  var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
+    toc: { list: { style: 'number', format: 'ordered' } }
+  });
+
+  t.same(
+    transformedContent.toc,
+    [
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '1. [My Module](#my-module)',
+        '  1.1. [API](#api)',
+        '    1.1.1. [Method One](#method-one)',
+        '    1.1.2. [Method Two](#method-two)',
+        '      1.1.2.1. [Main Usage](#main-usage)',
+        '  1.2. [Some More](#some-more)',
+        ''
+    ].join('\n'),
+    'TOC is correctly formatted'
+  )
+  t.end()
+});
+
+test('\nUppercase ToC ', function (t) {
+  var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
+  var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
+    toc: { list: { style: 'lowercase', format: 'ordered' } }
+  });
+
+  t.same(
+    transformedContent.toc,
+    [
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        'a. [My Module](#my-module)',
+        '  a.a. [API](#api)',
+        '    a.a.a. [Method One](#method-one)',
+        '    a.a.b. [Method Two](#method-two)',
+        '      a.a.b.a. [Main Usage](#main-usage)',
+        '  a.b. [Some More](#some-more)',
+        ''
+    ].join('\n'),
+    'TOC is correctly formatted'
+  )
+  t.end()
+});
+
+test('\nLowercase ToC ', function (t) {
+  var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
+  var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
+    toc: { list: { style: 'uppercase', format: 'ordered' } }
+  });
+
+  t.same(
+    transformedContent.toc,
+    [
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        'A. [My Module](#my-module)',
+        '  A.A. [API](#api)',
+        '    A.A.A. [Method One](#method-one)',
+        '    A.A.B. [Method Two](#method-two)',
+        '      A.A.B.A. [Main Usage](#main-usage)',
+        '  A.B. [Some More](#some-more)',
+        ''
+    ].join('\n'),
+    'TOC is correctly formatted'
+  )
+  t.end()
+});
+
+test('\nRoman ToC ', function (t) {
+  var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
+  var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
+    toc: { list: { style: 'roman', format: 'ordered' } }
+  });
+
+  t.same(
+    transformedContent.toc,
+    [
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        'I. [My Module](#my-module)',
+        '  I.I. [API](#api)',
+        '    I.I.I. [Method One](#method-one)',
+        '    I.I.II. [Method Two](#method-two)',
+        '      I.I.II.I. [Main Usage](#main-usage)',
+        '  I.II. [Some More](#some-more)',
+        ''
+    ].join('\n'),
+    'TOC is correctly formatted'
+  )
+  t.end()
+});
+
+test('\nUnordered ToC ', function (t) {
+  var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
+  var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
+    toc: { list: { style: 'number', format: 'unordered' } }
+  });
+
+  t.same(
+    transformedContent.toc,
+    [
+        '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+        '',
+        '- [My Module](#my-module)',
+        '  - [API](#api)',
+        '    - [Method One](#method-one)',
+        '    - [Method Two](#method-two)',
+        '      - [Main Usage](#main-usage)',
+        '  - [Some More](#some-more)',
+        ''
+    ].join('\n'),
+    'TOC is correctly formatted'
+  )
+  t.end()
+});

--- a/test/transform-list.js
+++ b/test/transform-list.js
@@ -29,7 +29,7 @@ test('\nNumerical ToC ', function (t) {
   t.end()
 });
 
-test('\nUppercase ToC ', function (t) {
+test('\nLowercase ToC ', function (t) {
   var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
   var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
     toc: { list: { style: 'lowercase', format: 'ordered' } }
@@ -53,7 +53,7 @@ test('\nUppercase ToC ', function (t) {
   t.end()
 });
 
-test('\nLowercase ToC ', function (t) {
+test('\nUppercase ToC ', function (t) {
   var content = fs.readFileSync(__dirname + '/fixtures/readme-formatting.md', 'utf8');
   var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
     toc: { list: { style: 'uppercase', format: 'ordered' } }
@@ -123,4 +123,37 @@ test('\nUnordered ToC ', function (t) {
     'TOC is correctly formatted'
   )
   t.end()
+});
+
+test('transforming list with skipping level', function (t) {
+  var content = [ 
+      '# My Module',
+      'Some text here',
+      '## API',
+      '### Method One',
+      '#### Main Usage',
+      'some main usage here',
+      '## Example',
+      '#### Example 1',
+      '#### Example 2',
+    ].join('\n');
+  var contents = [
+      '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*',
+      '',
+      '1. [My Module](#my-module)',
+      '  1.1. [API](#api)',
+      '    1.1.1. [Method One](#method-one)',
+      '      1.1.1.1. [Main Usage](#main-usage)',
+      '  1.2. [Example](#example)',
+      '      1.2.1.1. [Example 1](#example-1)',
+      '      1.2.1.2. [Example 2](#example-2)',
+      ''
+    ].join('\n');
+
+  var transformedContent = transform(content, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, { 
+    toc: { list: { style: 'number', format: 'ordered' } }
+  });
+
+  t.same(transformedContent.toc, contents, 'generates correct toc contents');
+  t.end();
 });

--- a/test/transform.js
+++ b/test/transform.js
@@ -1002,33 +1002,6 @@ check(
     , 'works like this'
     , '### Method Two'
     , '#### Main Usage'
-    , '## Some More'
-    ].join('\n')
-  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '1. [My Module](#my-module)\n'
-    , '  1.1. [API](#api)\n'
-    , '    1.1.1. [Method One](#method-one)\n'
-    , '    1.1.2. [Method Two](#method-two)\n'
-    , '      1.1.2.1. [Main Usage](#main-usage)\n'
-    , '  1.2. [Some More](#some-more)\n\n\n'
-    ].join('')
-  , undefined
-  , undefined
-  , undefined
-  , undefined
-  , undefined
-  , undefined
-  , 'number' // pass a collection as the prefix for toc entries
-)
-
-check(
-    [ '# My Module'
-    , 'Some text here'
-    , '## API'
-    , '### Method One'
-    , 'works like this'
-    , '### Method Two'
-    , '#### Main Usage'
     , 'some main usage here'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -1002,6 +1002,33 @@ check(
     , 'works like this'
     , '### Method Two'
     , '#### Main Usage'
+    , '## Some More'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '1 [My Module](#my-module)\n'
+    , '  1.1 [API](#api)\n'
+    , '    1.1.1 [Method One](#method-one)\n'
+    , '    1.1.2 [Method Two](#method-two)\n'
+    , '      1.1.2.1 [Main Usage](#main-usage)\n'
+    , '  1.2. [Some More](#some-more)\n\n\n'
+    ].join('')
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , undefined
+  , 'number' // pass a collection as the prefix for toc entries
+)
+
+check(
+    [ '# My Module'
+    , 'Some text here'
+    , '## API'
+    , '### Method One'
+    , 'works like this'
+    , '### Method Two'
+    , '#### Main Usage'
     , 'some main usage here'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'

--- a/test/transform.js
+++ b/test/transform.js
@@ -1005,11 +1005,11 @@ check(
     , '## Some More'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
-    , '1 [My Module](#my-module)\n'
-    , '  1.1 [API](#api)\n'
-    , '    1.1.1 [Method One](#method-one)\n'
-    , '    1.1.2 [Method Two](#method-two)\n'
-    , '      1.1.2.1 [Main Usage](#main-usage)\n'
+    , '1. [My Module](#my-module)\n'
+    , '  1.1. [API](#api)\n'
+    , '    1.1.1. [Method One](#method-one)\n'
+    , '    1.1.2. [Method Two](#method-two)\n'
+    , '      1.1.2.1. [Main Usage](#main-usage)\n'
     , '  1.2. [Some More](#some-more)\n\n\n'
     ].join('')
   , undefined


### PR DESCRIPTION
Closes: #257 

This adds support for ordered lists and not just unordered.

The style of ordered list can be used are:

- number (default)
- uppercase
- lowercase
- roman

The list handles levels ie 1.1.1

Note you must first select ordered as the list format to enable the style to have any effect.

