### PR TITLE
Add support for inserting anchors

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -112,6 +112,7 @@ function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel, synta
           , name :  extractText(x)
           , line :  x.loc.start.line
           , node :  x
+          , href : undefined // need to find a way to extract from, prev, next & current node
           };
       }
       else {
@@ -192,6 +193,30 @@ function detectLineEnding(content, defaultEol) {
   }
 
   return eol || defaultEol;
+}
+
+function getContentWithAnchors(docNodes, content, config, tocableStart, maxHeaderLevel, minHeaderLevel, eol){
+  var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel);
+  var newContent = '';
+  var startIndex = 0;
+
+  for (var i = 0; i < headers.length; i++) {
+    var header = headers[i];
+
+    if (header.href === undefined){
+      newContent += content.slice(startIndex, header.node.range[0]);
+      newContent += generateHeaderWithAnchor(header.node.raw, config, eol);
+      startIndex = header.node.range[1] + 1;
+    }
+  }
+
+  newContent += content.slice(startIndex);
+  return newContent;
+}
+
+function generateHeaderWithAnchor(text, config, eol){
+  // need to use config to build string
+  return text;
 }
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
@@ -280,6 +305,12 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
 
   var tocPosition = tocs.positions[0];
   var tocableStart = !processAll ? tocPosition.end.range[1] : startPos;
+
+  if (options?.anchor?.style && options.anchor.style != 'none'){
+    content = getContentWithAnchors(docNodes, content, options.anchor, tocableStart, maxHeaderLevel, minHeaderLevel, eol);
+    docNodes = md.parse(content);
+  }
+
   var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel, syntax)
     .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel, true));
 


### PR DESCRIPTION
Progresses: #174 
Closes: #218

This adds in the ability to insert anchors into the doc which is necessary for bit bucket server. However it has been in a generic manner enabling reuse. 