### PR TITLE
docs: improve README completness

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ by github or other sites via a command line flag.
 ## Supported Files
 
 Doctoc supports inserting TOCs into Markdown files detected via the CLI, with the tool accepting both file and directory paths.
-When a directory path is supplied, a recursive search is performed with only files having an extension listed below being processed.
+When a directory path is supplied, a recursive search is performed and only files with the following extensions are processed:
 
-- markdown
-- md
-- mdx
+ - `.md`
+ - `.markdown`
+ - `.mdx`
 
 > [!NOTE]
 > 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ by github or other sites via a command line flag.
 
 ## Supported Files
 
-Doctoc supports inserting toc's into any file supplied via the cli regardless of file extension.
-Alternatively directory/s can be supplied which results in toc's being inserted into files which have the following extensions:
+Doctoc supports inserting toc's into any file detected via the cli with the tool accepting both file and directory paths.
+When a directory path is supplied, a recursive search is performed with only files having an extension listed below being processed.
 
 - markdown
 - md
@@ -55,7 +55,7 @@ Alternatively directory/s can be supplied which results in toc's being inserted 
 
 > [!NOTE]
 > 
-> When using the directory option, both the '.git' and 'node_modules' directory will be ignored.
+> By default, the recursive search will ignore both, the '.git' and 'node_modules' directory if they exist.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by github or other sites via a command line flag.
 
 ## Supported Files
 
-Doctoc supports inserting toc's into any file detected via the cli with the tool accepting both file and directory paths.
+Doctoc supports inserting TOCs into Markdown files detected via the CLI, with the tool accepting both file and directory paths.
 When a directory path is supplied, a recursive search is performed with only files having an extension listed below being processed.
 
 - markdown
@@ -55,7 +55,7 @@ When a directory path is supplied, a recursive search is performed with only fil
 
 > [!NOTE]
 > 
-> By default, the recursive search will ignore both, the '.git' and 'node_modules' directory if they exist.
+> By default, the recursive search ignores the `.git` and `node_modules` directories (if they exist).
 
 ## Configuration
 
@@ -290,13 +290,13 @@ My Footer
 
 ## Exit Codes
 
-The cli tool utilises exit codes to inform the caller of the result of the execution.
-The current emitted exit codes and their description is:
+The CLI tool uses exit codes to inform the caller of the execution result.
+The currently emitted exit codes and their descriptions are:
 
 | Exit Code | Summary | Details |
 | --- | --- | --- |
-| 0 | Ok | The execution completed without any errors |
-| 1 | Document out of date | One or more files are out of date and need to be updated but wasn't due to performing a dry-run. |
+| 0 | OK | The execution completed without any errors |
+| 1 | Document out of date | One or more files are out of date and need to be updated, but weren’t updated because doctoc was run with `--dryrun`. |
 | 2 | Invalid config options | The supplied config is invalid. Consult logs for more details. |
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ by github or other sites via a command line flag.
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Installation](#installation)
+- [Supported Files](#supported-files)
 - [Configuration](#configuration)
   - [CLI Options](#cli-options)
     - [Logging level](#logging-level)
@@ -42,6 +43,19 @@ by github or other sites via a command line flag.
 ## Installation
 
     npm install -g doctoc
+
+## Supported Files
+
+Doctoc supports inserting toc's into any file supplied via the cli regardless of file extension.
+Alternatively directory/s can be supplied which results in toc's being inserted into files which have the following extensions:
+
+- markdown
+- md
+- mdx
+
+> [!NOTE]
+> 
+> When using the directory option, both the '.git' and 'node_modules' directory will be ignored.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ by github or other sites via a command line flag.
     - [List Options](#list-options)
     - [TOC Items](#toc-items)
     - [Footer](#footer)
+- [Exit Codes](#exit-codes)
 - [Usage](#usage)
   - [Adding toc to all files in a directory and sub directories](#adding-toc-to-all-files-in-a-directory-and-sub-directories)
   - [Ignoring individual files](#ignoring-individual-files)
@@ -272,6 +273,17 @@ For example, running `doctoc --toc-footer-content 'My Footer' .` would produce:
 My Footer
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ```
+
+## Exit Codes
+
+The cli tool utilises exit codes to inform the caller of the result of the execution.
+The current emitted exit codes and their description is:
+
+| Exit Code | Summary | Details |
+| --- | --- | --- |
+| 0 | Ok | The execution completed without any errors |
+| 1 | Document out of date | One or more files are out of date and need to be updated but wasn't due to performing a dry-run. |
+| 2 | Invalid config options | The supplied config is invalid. Consult logs for more details. |
 
 ## Usage
 


### PR DESCRIPTION
This adds the exit codes to the readme and also documents the supported files.