### PR TITLE
feat: Detect comment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Supported options are:
 
 > [!NOTE]
 >
-> By supplying a syntax, the files to be processed will be filtered ie html syntax is used in md & markdown files.
+> By specifying a syntax, the file scanner will filter the files to be processed based on the syntax & extension.
+> For instance, html syntax would result in only md & markdown files being processed.
 
 #### Min. Document Lines
 
@@ -130,6 +131,7 @@ By default,
 > If your document contains images, those images will not be counted any different to how plain text is,
 > as doctoc is processing your document as a text processor.
 > This also means repeated newlines will also be considered should your document contain them.
+
 #### Renderers
 
 In order to add a table of contents whose links are compatible with other sites add the appropriate mode flag:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Supported options are:
 - **md**: an alias for html. Will be removed in v3.
 - **mdx**: an alias for jsx. Will be removed in v3.
 
+> [!NOTE]
+>
+> By supplying a syntax, the files to be processed will be filtered ie html syntax is used in md & markdown files.
+
 #### Min. Document Lines
 
 Use the `--document-lines-min` option to specify the minimum lines required to be in a document for the document to have a table of contents; e.g., `doctoc --document-lines-min 200 .`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This is useful in CI environments where you want to check if your docs are up to
 
 You can print to stdout by using the `-s` or `--stdout` option.
 
-This option is only applicable when specifying a single filename which doctoc is to run on. If you are specifying a folder or multiple files, the dry run option should be used instead.
+This option is only applicable when specifying a single filename or a directory containing only 1 file which doctoc is to run on. If you are specifying a folder with multiple files or providing multiple inputs, the dry run option should be used instead.
 
 #### Update only
 
@@ -88,7 +88,7 @@ Use the `--syntax` option to specify the syntax used for comments in the documen
 
 Supported options are:
 
-- **jsx**: comments start with `{\*` and end with `*\}`.
+- **jsx**: comments start with `{/*` and end with `*/}`.
 - **html**: comments start with `<!--` and end with `-->`.
 - **md**: an alias for html. Will be removed in v3.
 - **mdx**: an alias for jsx. Will be removed in v3.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ by github or other sites via a command line flag.
     - [Stdout](#stdout)
     - [Update only](#update-only)
   - [Document Options](#document-options)
+    - [Comments](#comments)
     - [Min. Document Lines](#min-document-lines)
     - [Renderers](#renderers)
   - [Source Options](#source-options)
@@ -78,6 +79,19 @@ This option is only applicable when specifying a single filename which doctoc is
 Use `--update-only` or `-u` to only update the existing ToC. That is, the Markdown files without ToC will be left untouched. It is good if you want to use `doctoc` with `lint-staged`.
 
 ### Document Options
+
+#### Comments
+
+##### Syntax
+
+Use the `--syntax` option to specify the syntax used for comments in the documents. If not specified, syntax will be detected based on the file extension.
+
+Supported options are:
+
+- **jsx**: comments start with `{\*` and end with `*\}`.
+- **html**: comments start with `<!--` and end with `-->`.
+- **md**: an alias for html. Will be removed in v3.
+- **mdx**: an alias for jsx. Will be removed in v3.
 
 #### Min. Document Lines
 

--- a/doctoc.js
+++ b/doctoc.js
@@ -202,7 +202,7 @@ for (var i = 0; i < argv._.length; i++) {
   var files = file.findMarkdownFiles(argv._[i], argv['syntax']);
 
   if (files.length > 1 && stdOut) {
-    console.error('--stdout cannot be used to process a directory containing more than 1 file. Use --dryrun instead.');
+    console.error('--stdout cannot be used when more than 1 markdown file is found. Use --dryrun instead.');
     process.exitCode = 2;
     return;
   }

--- a/doctoc.js
+++ b/doctoc.js
@@ -24,7 +24,7 @@ function cleanPath(filePath) {
 }
 
 function detectSyntax(fileName){
-  var ext = path.extName(fileName);
+  var ext = path.extname(fileName);
   return extensions[ext];
 }
 

--- a/doctoc.js
+++ b/doctoc.js
@@ -2,31 +2,11 @@
 
 "use strict";
 
-var path = require("path"),
-  fs = require("fs"),
-  os = require("os"),
+var fs = require("fs"),
   minimist = require("minimist"),
   file = require("./lib/file"),
   transform = require("./lib/transform"),
-  log = require('loglevel'),
-  files;
-
-var extensions = {
-  mdx: 'jsx',
-  md: 'html', 
-  markdown: 'html',
-};
-
-function cleanPath(filePath) {
-  var homeExpanded = (filePath.indexOf('~') === 0) ? path.join(os.homedir(), filePath.substr(1)) : filePath;
-
-  return homeExpanded;
-}
-
-function detectSyntax(fileName){
-  var ext = path.extname(fileName);
-  return extensions[ext];
-}
+  log = require('loglevel');
 
 function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax, dryRun, options) {
   if (processAll) {
@@ -42,7 +22,7 @@ function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocIte
   var transformed = files
     .map(function (x) {
       var content = fs.readFileSync(x.path, 'utf8')
-        , result = transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax || detectSyntax(x.name), options);
+        , result = transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, x.syntax, options);
       result.path = x.path;
       return result;
     });
@@ -216,21 +196,12 @@ if (argv._.length > 1 && stdOut) {
 }
 
 for (var i = 0; i < argv._.length; i++) {
-  var target = cleanPath(argv._[i]),
-    stat = fs.statSync(target);
+  var files = file.findMarkdownFiles(argv._[i], syntax);
 
-  if (stat.isDirectory() && stdOut) {
-    console.error('--stdout cannot be used to process a directory. Use --dryrun instead.');
+  if (files.length > 1 && stdOut) {
+    console.error('--stdout cannot be used to process a directory containing more than 1 file. Use --dryrun instead.');
     process.exitCode = 2;
     return;
-  }
-
-  if (stat.isDirectory()) {
-    log.debug('\nDocToccing "%s" and its sub directories for %s.', target, mode);
-    files = file.findMarkdownFiles(target, syntax);
-  } else {
-    log.debug('\nDocToccing single file "%s" for %s.', target, mode);
-    files = [{ path: target, name: path.basename(target) }];
   }
 
   transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax, dryRun, options);

--- a/doctoc.js
+++ b/doctoc.js
@@ -11,10 +11,21 @@ var path = require("path"),
   log = require('loglevel'),
   files;
 
+var extensions = {
+  mdx: 'jsx',
+  md: 'html', 
+  markdown: 'html',
+};
+
 function cleanPath(filePath) {
   var homeExpanded = (filePath.indexOf('~') === 0) ? path.join(os.homedir(), filePath.substr(1)) : filePath;
 
   return homeExpanded;
+}
+
+function detectSyntax(fileName){
+  var ext = path.extName(fileName);
+  return extensions[ext];
 }
 
 function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax, dryRun, options) {
@@ -31,7 +42,7 @@ function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocIte
   var transformed = files
     .map(function (x) {
       var content = fs.readFileSync(x.path, 'utf8')
-        , result = transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options);
+        , result = transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax || detectSyntax(x.name), options);
       result.path = x.path;
       return result;
     });
@@ -83,7 +94,7 @@ function printUsageAndExit(isErr) {
   process.exit(isErr ? 2 : 0);
 }
 
-var supportedSyntaxes = ['md', 'mdx'];
+var supportedSyntaxes = ['html', 'jsx', 'md', 'mdx'];
 var modes = {
   bitbucket: "bitbucket.org",
   nodejs: "nodejs.org",
@@ -140,7 +151,7 @@ if (minTocItems && (isNaN(minTocItems) || minTocItems <= 0)) { log.error('Min. T
 var processAll = argv.all;
 var stdOut = argv.s || argv.stdout || false;
 var updateOnly = argv.u || argv['update-only'];
-var syntax = argv['syntax'] || 'md';
+var syntax = argv['syntax'];
 var dryRun = argv.d || argv.dryrun || false;
 
 var padBeforeTitle = argv['toc-title-padding-before'];
@@ -219,7 +230,7 @@ for (var i = 0; i < argv._.length; i++) {
     files = file.findMarkdownFiles(target, syntax);
   } else {
     log.debug('\nDocToccing single file "%s" for %s.', target, mode);
-    files = [{ path: target }];
+    files = [{ path: target, name: path.basename(target) }];
   }
 
   transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax, dryRun, options);

--- a/doctoc.js
+++ b/doctoc.js
@@ -8,7 +8,7 @@ var fs = require("fs"),
   transform = require("./lib/transform"),
   log = require('loglevel');
 
-function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax, dryRun, options) {
+function transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, dryRun, options) {
   if (processAll) {
     log.debug('--all flag is enabled. Including headers before the TOC location.');
   }
@@ -131,7 +131,6 @@ if (minTocItems && (isNaN(minTocItems) || minTocItems <= 0)) { log.error('Min. T
 var processAll = argv.all;
 var stdOut = argv.s || argv.stdout || false;
 var updateOnly = argv.u || argv['update-only'];
-var syntax = argv['syntax'];
 var dryRun = argv.d || argv.dryrun || false;
 
 var padBeforeTitle = argv['toc-title-padding-before'];
@@ -200,7 +199,7 @@ if (argv._.length > 1 && stdOut) {
 }
 
 for (var i = 0; i < argv._.length; i++) {
-  var files = file.findMarkdownFiles(argv._[i], syntax);
+  var files = file.findMarkdownFiles(argv._[i], argv['syntax']);
 
   if (files.length > 1 && stdOut) {
     console.error('--stdout cannot be used to process a directory containing more than 1 file. Use --dryrun instead.');
@@ -208,7 +207,7 @@ for (var i = 0; i < argv._.length; i++) {
     return;
   }
 
-  transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, syntax, dryRun, options);
+  transformAndSave(files, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, stdOut, updateOnly, dryRun, options);
 
   if (dryRun && process.exitCode === 1) {
     log.warn('\nDocumentation tables of contents are out of date.');

--- a/lib/content-generation.js
+++ b/lib/content-generation.js
@@ -1,12 +1,12 @@
 "use strict";
 
 var commentTypes = {
-  md: {
+  html: {
     start: "<!--",
     end: "-->",
     escapedStart: "<!--",
   },
-  mdx: {
+  jsx: {
     start: "{/*",
     end: "*/}",
     escapedStart: "{\/\\*",

--- a/lib/content-generation.js
+++ b/lib/content-generation.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { normalizeSyntax } = require("./utils/helpers");
+
 var commentTypes = {
   html: {
     start: "<!--",
@@ -38,8 +40,8 @@ function compactPragma(syntax) {
 }
 
 function commentedBlock(syntax, content) {
-  if (syntax == "md") syntax = "html";
-  if (syntax == "mdx") syntax = "jsx";
+  // TODO: remove in v3
+  syntax = normalizeSyntax(syntax, "html");
 
   var commentStart = commentTypes[syntax].start
   , commentEnd = commentTypes[syntax].end;
@@ -55,8 +57,8 @@ function excludeTag(syntax) {
 }
 
 function escapedStartTag(syntax) {
-  if (syntax == "md") syntax = "html";
-  if (syntax == "mdx") syntax = "jsx";
+  // TODO: remove in v3
+  syntax = normalizeSyntax(syntax, "html");
 
   return commentTypes[syntax].escapedStart;
 }

--- a/lib/content-generation.js
+++ b/lib/content-generation.js
@@ -38,6 +38,9 @@ function compactPragma(syntax) {
 }
 
 function commentedBlock(syntax, content) {
+  if (syntax == "md") syntax = "html";
+  if (syntax == "mdx") syntax = "jsx";
+
   var commentStart = commentTypes[syntax].start
   , commentEnd = commentTypes[syntax].end;
   return `${commentStart} ${content} ${commentEnd}`;
@@ -48,6 +51,9 @@ function skipTag(syntax) {
 }
 
 function escapedStartTag(syntax) {
+  if (syntax == "md") syntax = "html";
+  if (syntax == "mdx") syntax = "jsx";
+
   return commentTypes[syntax].escapedStart;
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,9 +1,19 @@
 var path = require("path"),
   fs = require("fs"),
+  os = require("os"),
   log = require('loglevel');
 
 var ignoredDirs  = ['.', '..', '.git', 'node_modules'];
-var extensions = ['mdx', 'md', 'markdown'];
+var allowedExts = ['.mdx', '.md', '.markdown'];
+var syntaxMapping = {
+  '.mdx': 'jsx',
+  '.md': 'html', 
+  '.markdown': 'html',
+};
+
+function cleanPath(filePath) {
+  return (filePath.indexOf('~') === 0) ? path.join(os.homedir(), filePath.substr(1)) : filePath;
+}
 
 function findRec(paths, syntax) {
   var results = [];
@@ -21,10 +31,12 @@ function findRec(paths, syntax) {
         stack.push(fullPath);
       }
 
-      if (fileInfo.isFile() && extensions.includes(path.extname(fileInfo.name))) {
+      if (fileInfo.isFile() && allowedExts.includes(path.extname(fileInfo.name)) &&
+          (syntax === undefined || syntax === syntaxMapping[path.extname(fileInfo.name)])) {
         markdownFiles.push({
           path: fullPath,
-          name: fileInfo.name
+          name: fileInfo.name,
+          syntax: syntax ?? syntaxMapping[path.extname(fileInfo.name)]
         });
       }
     }
@@ -43,5 +55,17 @@ function findRec(paths, syntax) {
 // Finds all markdown files in given directory and its sub-directories
 // @param {String  } dir - the absolute directory to search in
 exports.findMarkdownFiles = function (dir, syntax) {
-  return findRec([dir], syntax);
+  var target = cleanPath(dir);
+  var stat = fs.statSync(target);
+  if (stat.isDirectory()) {
+    log.debug('\nDocToccing "%s" and its sub directories', dir);
+    return findRec([target], syntax);
+  } else {
+    log.debug('\nDocToccing single file "%s".', dir);
+    return [{
+      path: target,
+      name: path.basename(target),
+      syntax: syntax ?? syntaxMapping[path.extname(path.basename(target))]
+    }];
+  }
 };

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,13 +3,9 @@ var path = require("path"),
   log = require('loglevel');
 
 var ignoredDirs  = ['.', '..', '.git', 'node_modules'];
-var extensions = {
-  mdx: ['.mdx'],
-  md: ['.md', '.markdown'],
-};
+var extensions = ['mdx', 'md', 'markdown'];
 
 function findRec(paths, syntax) {
-  var allowedExts = extensions[syntax] || [];
   var results = [];
   var stack = [...paths];
 
@@ -25,7 +21,7 @@ function findRec(paths, syntax) {
         stack.push(fullPath);
       }
 
-      if (fileInfo.isFile() && allowedExts.includes(path.extname(fileInfo.name))) {
+      if (fileInfo.isFile() && extensions.includes(path.extname(fileInfo.name))) {
         markdownFiles.push({
           path: fullPath,
           name: fileInfo.name

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,3 +1,5 @@
+const { normalizeSyntax } = require("./utils/helpers");
+
 var path = require("path"),
   fs = require("fs"),
   os = require("os"),
@@ -57,6 +59,8 @@ function findRec(paths, syntax) {
 exports.findMarkdownFiles = function (dir, syntax) {
   var target = cleanPath(dir);
   var stat = fs.statSync(target);
+  // TODO: remove in v3
+  syntax = normalizeSyntax(syntax);
   if (stat.isDirectory()) {
     log.debug('\nDocToccing "%s" and its sub directories', dir);
     return findRec([target], syntax);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,4 +1,5 @@
 "use strict";
+const { normalizeSyntax } = require("./utils/helpers");
 
 var anchor = require("anchor-markdown-header"),
   getHtmlHeaders = require("./get-html-headers"),
@@ -200,9 +201,8 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   options.toc.items ??= {};
   options.toc.items.indentation ??= {};
 
-  syntax ??= "html";
-  if (syntax == "md") syntax = "html";
-  if (syntax == "mdx") syntax = "jsx";
+  // TODO: replace with syntax ??= "html" in v3
+  syntax = normalizeSyntax(syntax, "html");
   options.toc.items.indentation.style ??= 'space';
   options.toc.items.indentation.width ??= options.toc.items.indentation.style === 'tab' ? 1 : (
     mode === 'bitbucket.org' || mode === 'gitlab.com' ? 4 : 2

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -29,7 +29,7 @@ function getTocMarkers(docNodes, pragmaStyle, syntax, eol) {
   var matchesStartBySyntax = matchesStart(syntax);
   var matchesEndBySyntax = matchesEnd(syntax);
   var nodes = docNodes.children.filter(function (x) {
-      return ((x.type === md.Syntax.Html || x.type === md.Syntax.HtmlBlock) && syntax === "md") || (x.type === md.Syntax.Paragraph && syntax === "mdx");
+      return ((x.type === md.Syntax.Html || x.type === md.Syntax.HtmlBlock) && syntax === "html") || (x.type === md.Syntax.Paragraph && syntax === "jsx");
     })
     .map(function (x) {
       if(matchesStartBySyntax(x.raw)){

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -199,7 +199,9 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   options.toc ??= {};
   options.toc.items ??= {};
 
-  syntax = syntax || "md";
+  syntax = syntax || "html";
+  if (syntax == "md") syntax = "html";
+  if (syntax == "mdx") syntax = "jsx";
   options.toc.items.symbols ??= String(entryPrefix || "-").split(',');
   var eol = '\n';
   eol = detectLineEnding(content, eol);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -200,14 +200,14 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   options.toc.items ??= {};
   options.toc.items.indentation ??= {};
 
-  syntax = syntax || "html";
+  syntax ??= "html";
   if (syntax == "md") syntax = "html";
   if (syntax == "mdx") syntax = "jsx";
   options.toc.items.indentation.style ??= 'space';
   options.toc.items.indentation.width ??= options.toc.items.indentation.style === 'tab' ? 1 : (
     mode === 'bitbucket.org' || mode === 'gitlab.com' ? 4 : 2
   );
-  options.toc.items.symbols ??= String(entryPrefix || "-").split(',');
+  options.toc.items.symbols ??= String(entryPrefix || '-').split(',');
 
   var eol = '\n';
   eol = detectLineEnding(content, eol);

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,0 +1,12 @@
+"use strict";
+
+function normalizeSyntax(syntax, defaultSyntax) {
+  syntax ??= defaultSyntax;
+  if (syntax == "md") syntax = "html";
+  if (syntax == "mdx") syntax = "jsx";
+  return syntax;
+}
+
+module.exports = {
+  normalizeSyntax
+};

--- a/test/file.js
+++ b/test/file.js
@@ -6,28 +6,44 @@ var test = require('tap').test,
 
 const fixturesDir = __dirname + "/fixtures"
 test('\nmatch mdx files only with syntax=mdx', function (t) {
+  var files = findMarkdownFiles(fixturesDir, 'mdx');
   t.same(
-    findMarkdownFiles(fixturesDir, 'mdx').every((file) => file.path.endsWith(".mdx"))
-    , true
-    , 'match mdx files only with syntax=mdx'
-  )
-  t.end()
+    files.length > 0 && files.every((file) => file.path.endsWith(".mdx")),
+    true,
+    'match mdx files only with syntax=mdx'
+  );
+  t.end();
 });
 
 test('\nmatch md files only with syntax=md', function (t) {
+  var files = findMarkdownFiles(fixturesDir, 'md');
   t.same(
-    findMarkdownFiles(fixturesDir, 'md').every((file) => file.path.endsWith(".md"))
-    , true
-    , 'match md files only with syntax=md'
-  )
-  t.end()
+    files.length > 0 && files.every((file) => file.path.endsWith(".md")),
+    true,
+    'match md files only with syntax=md'
+  );
+  t.end();
 });
 
-test('\nmatch md files only with undefined syntax', function (t) {
+test('\nmatch md, mdx etc files when undefined syntax', function (t) {
+  var files = findMarkdownFiles(fixturesDir);
   t.same(
-    findMarkdownFiles(fixturesDir, 'md').every((file) => file.path.endsWith(".md"))
-    , true
-    , 'match md files only with undefined syntax'
-  )
-  t.end()
+    files.length > 0 && files.every((file) => file.path.endsWith(".md") ||
+      file.path.endsWith(".mdx") ||
+      file.path.endsWith(".markdown")
+    ),
+    true,
+    'match multiple file types when undefined syntax'
+  );
+  t.same(
+    files.every((file) => file.path.endsWith(".md")),
+    false,
+    'not all files are md files when undefined syntax'
+  );
+  t.same(
+    files.every((file) => file.path.endsWith(".mdx")),
+    false,
+    'not all files are mdx files when undefined syntax'
+  );
+  t.end();
 });

--- a/test/fixtures/invalid_stdout/content.md
+++ b/test/fixtures/invalid_stdout/content.md
@@ -1,0 +1,18 @@
+# Hello, world!
+
+README to test doctoc with stdout on a directory.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Installation](#installation)
+- [API](#api)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Installation
+## API
+## License

--- a/test/fixtures/readme-with-custom-title.mdx
+++ b/test/fixtures/readme-with-custom-title.mdx
@@ -1,0 +1,17 @@
+# Hello, world!
+
+README to test doctoc with user-specified titles.
+
+{/* START doctoc generated TOC please keep comment here to allow auto update */}
+{/* DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE */}
+## Table of Contents
+
+- [Installation](#installation)
+- [API](#api)
+- [License](#license)
+
+{/* END doctoc generated TOC please keep comment here to allow auto update */}
+
+## Installation
+## API
+## License

--- a/test/fixtures/stdout_trace.log
+++ b/test/fixtures/stdout_trace.log
@@ -1,5 +1,5 @@
 
-DocToccing single file "test/fixtures/readme-with-custom-title.md" for github.com.
+DocToccing single file "test/fixtures/readme-with-custom-title.md".
 
 ==================
 

--- a/test/fixtures/valid_stdout/readme.md
+++ b/test/fixtures/valid_stdout/readme.md
@@ -1,0 +1,18 @@
+# Hello, world!
+
+README to test doctoc with stdout on a directory.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Installation](#installation)
+- [API](#api)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Installation
+## API
+## License

--- a/test/transform-dryrun.js
+++ b/test/transform-dryrun.js
@@ -68,7 +68,7 @@ test('\nshould exit with no error code with --dryrun, --github and --update-only
     })
 })
 
-test('\nshould exit with no error code with --dryrun, --github and --update-only options', function (t) {
+test('\nshould exit with no error code with --dryrun, --github and --update-only options (mdx)', function (t) {
 
     exec('node doctoc.js test/fixtures/readme-with-custom-title.mdx --dryrun --github --update-only', function (error, stdout, stderr) {
       if (error) {
@@ -116,7 +116,7 @@ test('\nshould exit with no error code', function (t) {
     })
 })
 
-test('\nshould exit with no error code', function (t) {
+test('\nshould exit with no error code (mdx fixture)', function (t) {
 
     exec('node doctoc.js test/fixtures/readme-with-custom-title.mdx', function (error, stdout, stderr) {
       if (error) {

--- a/test/transform-dryrun.js
+++ b/test/transform-dryrun.js
@@ -70,6 +70,18 @@ test('\nshould exit with no error code with --dryrun, --github and --update-only
 
 test('\nshould exit with no error code with --dryrun, --github and --update-only options', function (t) {
 
+    exec('node doctoc.js test/fixtures/readme-with-custom-title.mdx --dryrun --github --update-only', function (error, stdout, stderr) {
+      if (error) {
+        t.fail('process produced an unexpected error: ' + error);
+        t.end()
+      } else {
+        t.end('process did not have an error');
+      }
+    })
+})
+
+test('\nshould exit with no error code with --dryrun, --github and --update-only options', function (t) {
+
     exec('node doctoc.js test/fixtures/readme-with-notitle.md --dryrun --github --update-only', function (error, stdout, stderr) {
       if (error) {
         t.fail('process produced an unexpected error: ' + error);
@@ -95,6 +107,18 @@ test('\nshould exit no error code when not using --dryrun and using --all for ou
 test('\nshould exit with no error code', function (t) {
 
     exec('node doctoc.js test/fixtures/readme-with-custom-title.md', function (error, stdout, stderr) {
+      if (error) {
+        t.fail('process produced an unexpected error: ' + error);
+        t.end()
+      } else {
+        t.end('process did not have an error');
+      }
+    })
+})
+
+test('\nshould exit with no error code', function (t) {
+
+    exec('node doctoc.js test/fixtures/readme-with-custom-title.mdx', function (error, stdout, stderr) {
       if (error) {
         t.fail('process produced an unexpected error: ' + error);
         t.end()

--- a/test/transform-stdout.js
+++ b/test/transform-stdout.js
@@ -50,14 +50,25 @@ test('\nshould print to stdout with --stdout option and default logging aka info
     })
 })
 
-test('\nshould exit with error code as --stdout option is not supported on a directory', function (t) {
+test('\nshould exit with no error code as --stdout option is supported on a directory with 1 file', function (t) {
+
+    exec('node doctoc.js test/fixtures/valid_stdout --stdout', function (error, stdout, stderr) {
+      if (error) {
+        console.error('exec error: ', error);
+        return;
+      }
+      t.end();
+    })
+})
+
+test('\nshould exit with error code as --stdout option is not supported on a directory with multiple files', function (t) {
 
     exec('node doctoc.js test/fixtures/invalid_stdout --stdout', function (error, stdout, stderr) {
       if (error) {
         t.same(error.code, 2, 'process exited with error code 2 as expected');
         t.end();
       } else {
-        t.fail('process did not produce an error: ' + error);
+        t.fail('process did not produce an error.');
         t.end();
       }
     })
@@ -70,7 +81,7 @@ test('\nshould exit with error code as --stdout option is not supported on multi
         t.same(error.code, 2, 'process exited with error code 2 as expected');
         t.end();
       } else {
-        t.fail('process did not produce an error: ' + error);
+        t.fail('process did not produce an error.');
         t.end();
       }
     })

--- a/test/transform-stdout.js
+++ b/test/transform-stdout.js
@@ -54,7 +54,8 @@ test('\nshould exit with no error code as --stdout option is supported on a dire
 
     exec('node doctoc.js test/fixtures/valid_stdout --stdout', function (error, stdout, stderr) {
       if (error) {
-        console.error('exec error: ', error);
+        t.fail('process produced an unexpected error: ' + error);
+        t.end();
         return;
       }
       t.end();

--- a/test/transform.js
+++ b/test/transform.js
@@ -11,7 +11,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 
     // build the expected content
     eol = eol || '\n';
-    var pragma = contentGenerator.pragmaMarkers(syntax || 'md', 'legacy', eol);
+    var pragma = contentGenerator.pragmaMarkers(syntax || 'html', 'legacy', eol);
     var body = '';
     var doc = '';
     var tag = md.substring(0, 3);

--- a/test/transform.js
+++ b/test/transform.js
@@ -11,7 +11,7 @@ function check(md, anchors, mode, maxHeaderLevel, minHeaderLevel, minTocItems, t
 
     // build the expected content
     eol = eol || '\n';
-    var pragma = contentGenerator.pragmaMarkers(syntax || 'html', 'legacy', eol);
+    var pragma = contentGenerator.pragmaMarkers(syntax || 'md', 'legacy', eol);
     var body = '';
     var doc = '';
     var tag = md.substring(0, 3);


### PR DESCRIPTION
I noticed that the syntax option is not documented. While writing the doc and checking the implementation the opportunity to streamline the implementation was identified. This streamlining helps with the documentation.

The changes are:
- syntax defaults to being detected based on file extension
- Syntax options now match syntax type ie html, jsx with determination occurring during filesystem scanning.

the benefit is we can support mixed environments ie mdx & md within the same workspace.