### PR TITLE
fix: use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0-development",
   "repository": {
     "type": "git",
-    "url": "git://github.com/thlorenz/doctoc.git"
+    "url": "git+https://github.com/thlorenz/doctoc.git"
   },
   "scripts": {
     "test": "tap",


### PR DESCRIPTION
## Summary

Update `package.json#repository.url` from the legacy unauthenticated `git://` transport to `git+https://`.

The currently published `doctoc@2.5.0` exposes:

```text
git://github.com/thlorenz/doctoc.git
```

This change makes the metadata work in environments where the Git protocol is blocked while preserving the same canonical repository.

## Verification

- parsed the modified `package.json` successfully
- confirmed the repository owner/name remains `thlorenz/doctoc`
- no runtime code, dependency, lockfile, version, or package contents changed

```text
git+https://github.com/thlorenz/doctoc.git
```