### PR TITLE
Add Tap-generated nyc coverage output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp_samples
 !test/fixtures/*.log
 .idea
 .tap
+.nyc_output/


### PR DESCRIPTION
## Summary

- Add `.nyc_output/` to `.gitignore`
- Keep Tap/nyc coverage output from showing up as untracked local files