### PR TITLE
feat: Full support of min level via sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,15 @@ An example is:
 ##### Min. level
 
 Use the `--minlevel` option to limit TOC entries to headings only at or above the specified level; e.g., `doctoc --minlevel 2 .`
+The headers in the document will be grouped into sections, with a new section formed when a header is processed which is lower than the defined min.
 
 By default,
 
 - the min level used is 1 if it is not set
 
-Note: Currently supported values are only 1 and 2.
+> [!NOTE]
+>
+> Currently if the document has more than 1 section, the toc generation will fail with a warning level.
 
 ##### Max. level
 

--- a/doctoc.js
+++ b/doctoc.js
@@ -152,7 +152,6 @@ if (maxHeaderLevel && isNaN(maxHeaderLevel)) { log.error('Max. heading level spe
 
 var minHeaderLevel = argv.minlevel || 1;
 if (minHeaderLevel && isNaN(minHeaderLevel) || minHeaderLevel < 0) { log.error('Min. heading level specified is not a positive number: ' + minHeaderLevel), printUsageAndExit(true); }
-else if (minHeaderLevel && minHeaderLevel > 2) { log.error('Min. heading level: ' + minHeaderLevel + ' is not currently supported as greater than 2'), printUsageAndExit(true); }
 
 if (maxHeaderLevel && maxHeaderLevel < minHeaderLevel) { log.error('Max. heading level: ' + maxHeaderLevel + ' is less than the defined Min. heading level: ' + minHeaderLevel), printUsageAndExit(true); }
 

--- a/lib/get-html-headers.js
+++ b/lib/get-html-headers.js
@@ -3,49 +3,18 @@
 var htmlparser = require("htmlparser2"),
   md = require("@textlint/markdown-to-ast");
 
-function addLinenos(lines, headers) {
-  var current = 0, line;
-
-  return headers.map(function (x) {
-    for (var lineno = current; lineno < lines.children.length; lineno++) {
-      line = lines.children[lineno];
-      if (new RegExp(x.text[0]).test(line.raw)) {
-        x.line = line.loc.start.line;
-        x.name = x.text.join("");
-        return x;
-      }
-    }
-
-    // in case we didn't find a matching line, which is odd,
-    // we'll have to assume it's right on the next line
-    x.line = ++current;
-    x.name = x.text.join("");
-    return x;
-  });
+function validMdHtmlHeader (html, maxHeaderLevel, nested) {
+  if (nested === undefined) return true;
+  if (html[0] !== '<' || html[1] !== 'h') return nested;
+  var position = html.indexOf('<h', 3);
+  if (nested ? position === -1 : position !== -1) return false;
+  const level = html[2];
+  if (!html.endsWith('</h' + level + '>')) return nested;
+  if (nested) return true;
+  return Number(level) <= (maxHeaderLevel || 4);
 }
 
-var go = (module.exports = function (nodes, start, maxHeaderLevel, minHeaderLevel, nested) {
-  function validMdHtmlHeader (html, minHeaderLevel, maxHeaderLevel, nested) {
-    if (nested === undefined) return true;
-    if (html[0] !== '<' || html[1] !== 'h') return nested;
-    var position = html.indexOf('<h', 3);
-    if (nested ? position === -1 : position !== -1) return false;
-    const level = html[2];
-    if (!html.endsWith('</h' + level + '>')) return nested;
-    if (nested) return true;
-    return Number(level) >= minHeaderLevel && Number(level) <= (maxHeaderLevel || 4);
-  }
-
-  var source = nodes
-    .children.filter(function (node) {
-      return (node.type === md.Syntax.HtmlBlock || node.type === md.Syntax.Html) && validMdHtmlHeader(node.raw, minHeaderLevel, maxHeaderLevel, nested) && node.range[1] > start;
-    })
-    .map(function (node) {
-      return node.raw;
-    })
-    .join("\n");
-
-  //var headers = [], grabbing = null, text = [];
+function processNode(node){
   var currentLine = 1,
     headers = [],
     grabbing = [],
@@ -58,7 +27,7 @@ var go = (module.exports = function (nodes, start, maxHeaderLevel, minHeaderLeve
         if (grabbing[grabbing.length - 1]?.tagName === "pre") return;
 
         if (name === "pre" || /h\d/.test(name)) {
-          grabbing.push({ tagName: name, line: currentLine, tagId: attr.id });
+          grabbing.push({ tagName: name, line: currentLine, tagId: attr.id, start: parser.startIndex + node.range[0] });
         }
       },
       ontext: function (text_) {
@@ -79,11 +48,21 @@ var go = (module.exports = function (nodes, start, maxHeaderLevel, minHeaderLeve
           grabbing.pop();
         }
       },
-      onclosetag: function (name) {
+      onclosetag: function (name, isImplied) {
+        if (isImplied) return;
         if (grabbing.length === 0) return;
         if (grabbing[grabbing.length - 1].tagName === name) {
           var tag = grabbing.pop();
-          headers.push({ text: text, tagName: tag.tagName, href: tag.tagId, rank: parseInt(tag.tagName.slice(1), 10) });
+          var end = parser.endIndex + node.range[0];
+          headers.push({
+            text: text, 
+            tagName: tag.tagName, 
+            href: tag.tagId, 
+            rank: parseInt(tag.tagName.slice(1), 10),
+            node: { range: [tag.start, end],loc: node.loc },
+            line: node.loc.start.line,
+            name: text.join("")
+          });
           text = [];
         }
       },
@@ -91,13 +70,22 @@ var go = (module.exports = function (nodes, start, maxHeaderLevel, minHeaderLeve
     { decodeEntities: true },
   );
 
-  parser.write(source);
+  parser.write(node.raw);
   parser.end();
+  return headers;
+}
 
-  headers = addLinenos(nodes, headers);
+var go = (module.exports = function (nodes, start, maxHeaderLevel, minHeaderLevel, nested) {
+  var headers = nodes.children.filter(function (node) {
+      return (node.type === md.Syntax.HtmlBlock || node.type === md.Syntax.Html) && validMdHtmlHeader(node.raw, maxHeaderLevel, nested) && node.range[1] > start;
+    })
+    .map(function (node) {
+      return processNode(node);
+    }).flat();
+
   // consider anything past h4 to small to warrant a link, may be made configurable in the future
   headers = headers.filter(function (x) {
-    return x.rank <= (maxHeaderLevel || 4) && x.rank >= minHeaderLevel;
+    return x.rank <= (maxHeaderLevel || 4);
   });
   return headers;
 });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -31,47 +31,51 @@ function getSections(docNodes, headers, options, syntax, eol, processAll, insert
   var newSection = null;
   var sections = [];
   var startPos = 0;
-  var previousHeader;
+  var previousSectionSplit;
 
   if(!processAll && markers.positions?.length > 0){
     startPos = markers.positions[0].end.range[1];
   }
 
   for (var i = 0; i < headers.length; i++){
-    // a new section is needed if the header is below the min header level, or if it is above the min header level but comes before the start position (which would be the case if there is an existing TOC and we're skipping it)
+    // a new section is needed if the header is below the min header level and we are already in a section
     if (newSection && headers[i].rank < minHeaderLevel){
       sections.push(newSection);
       newSection = null;
     }
-    // move to next header if below min header level or before start position
-    if (headers[i].rank < minHeaderLevel || headers[i].node.range[0] < startPos){
+    // move to next header if before start position
+    if (headers[i].node.range[0] < startPos){
       continue;
     }
-    if(!newSection && options.toc.location?.toLowerCase() == 'before'){
+    // move to next header if below min header level but capture it so it can be used to calculate insert pos
+    else if (headers[i].rank < minHeaderLevel){
+      previousSectionSplit = headers[i];
+      continue;
+    }
+    if(!newSection && options.toc.location?.toLowerCase() === 'before'){
       insertPos = headers[i].node.range[0];
     }
-    else if(!newSection && options.toc.location?.toLowerCase() == 'top'){
-      insertPos = previousHeader ? previousHeader.node.range[1] : insertPos;
+    else if(!newSection && options.toc.location?.toLowerCase() === 'top'){
+      insertPos = previousSectionSplit ? previousSectionSplit.node.range[1] : insertPos;
     }
 
     //use found marker position in process all mode
     if (processAll && !newSection && markers.positions?.length == 1){
       newSection = markers.positions[0];
     }
-    //find the first marker position that comes before the header
+    //find the first marker position that comes before the header but after section split
     else if (!newSection && markers.positions?.length > 0) {
       newSection = markers.positions.filter(function (x){
         return x.end.range[1] < headers[i].node.range[0] &&
-          x.start.range[0] >= (previousHeader ? previousHeader.node.range[1] : insertPos);
+          x.start.range[0] >= (previousSectionSplit ? previousSectionSplit.node.range[1] : insertPos);
       })?.[0];
     }
-    // if the header falls within the current new section, don't capture it
+    // if the header falls within the current toc in the new section, don't capture it
     if (newSection && 
       newSection.end.range[1] > headers[i].node.range[0] &&
       newSection.start.range[0] < headers[i].node.range[1]){
       continue;
     }
-    previousHeader = headers[i];
     if (newSection) {
       newSection.headings.push(headers[i]);
     }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -2,6 +2,7 @@
 
 var anchor = require("anchor-markdown-header"),
   getHtmlHeaders = require("./get-html-headers"),
+  log = require('loglevel'),
   contentGenerator = require("./content-generation"),
   md = require("@textlint/markdown-to-ast");
 
@@ -25,6 +26,94 @@ function isString(y) {
   return typeof y === 'string';
 }
 
+function getSections(docNodes, headers, options, syntax, eol, processAll, insertPos, minHeaderLevel){
+  var markers = getTocMarkers(docNodes, options.toc.pragma.style, syntax, eol);
+  var newSection = null;
+  var sections = [];
+  var startPos = 0;
+  var previousHeader;
+
+  if(!processAll && markers.positions?.length > 0){
+    startPos = markers.positions[0].end.range[1];
+  }
+
+  for (var i = 0; i < headers.length; i++){
+    // a new section is needed if the header is below the min header level, or if it is above the min header level but comes before the start position (which would be the case if there is an existing TOC and we're skipping it)
+    if (newSection && headers[i].rank < minHeaderLevel){
+      sections.push(newSection);
+      newSection = null;
+    }
+    // move to next header if below min header level or before start position
+    if (headers[i].rank < minHeaderLevel || headers[i].node.range[0] < startPos){
+      continue;
+    }
+    if(!newSection && options.toc.location?.toLowerCase() == 'before'){
+      insertPos = headers[i].node.range[0];
+    }
+    else if(!newSection && options.toc.location?.toLowerCase() == 'top'){
+      insertPos = previousHeader ? previousHeader.node.range[1] : insertPos;
+    }
+
+    //use found marker position in process all mode
+    if (processAll && !newSection && markers.positions?.length == 1){
+      newSection = markers.positions[0];
+    }
+    //find the first marker position that comes before the header
+    else if (!newSection && markers.positions?.length > 0) {
+      newSection = markers.positions.filter(function (x){
+        return x.end.range[1] < headers[i].node.range[0] &&
+          x.start.range[0] >= (previousHeader ? previousHeader.node.range[1] : insertPos);
+      })?.[0];
+    }
+    // if the header falls within the current new section, don't capture it
+    if (newSection && 
+      newSection.end.range[1] > headers[i].node.range[0] &&
+      newSection.start.range[0] < headers[i].node.range[1]){
+      continue;
+    }
+    previousHeader = headers[i];
+    if (newSection) {
+      newSection.headings.push(headers[i]);
+    }
+    else {
+      newSection = {
+        end: {
+          range: [insertPos, insertPos],
+          raw: markers.marker.end,
+        },
+        start: {
+          range: [insertPos, insertPos],
+          raw: markers.marker.start,
+        },
+        headings: [headers[i]],
+        existing: false
+      };
+    }
+    if (processAll) {
+      newSection.headings = headers;
+      break
+    }
+  }
+  if (newSection) {
+      sections.push(newSection);
+  }
+  else{
+    sections.push({
+      end: {
+        range: [insertPos, insertPos],
+        raw: markers.marker.end,
+      },
+      start: {
+        range: [insertPos, insertPos],
+        raw: markers.marker.start,
+      },
+      headings: [headers[i]],
+      existing: false
+    });
+  }
+  return sections;
+}
+
 function getTocMarkers(docNodes, pragmaStyle, syntax, eol) {
   var matchesStartBySyntax = matchesStart(syntax);
   var matchesEndBySyntax = matchesEnd(syntax);
@@ -46,30 +135,38 @@ function getTocMarkers(docNodes, pragmaStyle, syntax, eol) {
 
   var marker = contentGenerator.pragmaMarkers(syntax, pragmaStyle, eol);
   
-  // This finds the position of the existing toc markers
-  var position = nodes.length < 2 ? null : {
-    start: nodes.find(n => n.type === "start")?.node,
-    end: nodes.find(n => n.type === "end")?.node,
-  };
-  if (!position) {
-    return { marker: marker };
+  var positions = [];
+  for (var i = 0; i < nodes.length; i++){
+    var start = nodes[i];
+    var end = nodes[i+1];
+    if (start.type == 'start' && end?.type == 'end'){
+      var position = {
+        start: start.node,
+        end: end.node,
+        existing: start.node != undefined && end.node != undefined,
+        headings: [],
+        raw: docNodes.raw.slice(start.node.range[0], end.node.range[1])
+      };
+
+      if (pragmaStyle == "compact" && position?.existing) {
+        position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
+        position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
+      }
+      else if ((pragmaStyle == "legacy" || !pragmaStyle) && position?.existing) {
+        // Replace the old START comment with the canonical two-line marker (START + DON'T EDIT).
+        // Update range[1] to match so that determineTitle searches *after* both lines,
+        // preventing the DON'T EDIT comment from being mistaken for a title.
+        position.start.raw = marker.start;
+        position.start.range[1] = position.start.range[0] + marker.start.length;
+      }
+      i++;
+      positions.push(position)
+    }
   }
-  position.existing = position.start && position.end;
-  if (pragmaStyle == "compact" && position?.existing) {
-    position.start.raw = position.start.raw.replace(" generated TOC please keep comment here to allow auto update", "");
-    position.end.raw = position.end.raw.replace(" generated TOC please keep comment here to allow auto update", "");
-  }
-  else if ((pragmaStyle == "legacy" || !pragmaStyle) && position?.existing) {
-    // Replace the old START comment with the canonical two-line marker (START + DON'T EDIT).
-    // Update range[1] to match so that determineTitle searches *after* both lines,
-    // preventing the DON'T EDIT comment from being mistaken for a title.
-    position.start.raw = marker.start;
-    position.start.range[1] = position.start.range[0] + marker.start.length;
-  }
-  return { marker: marker, positions: [position] };
+  return { marker: marker, positions: positions };
 }
 
-function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel, syntax) {
+function getMarkdownHeaders (lines, start, maxHeaderLevel, syntax) {
   function extractText (header) {
     return header.children
       .map(function (x) {
@@ -98,7 +195,7 @@ function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel, synta
     })
     .map(function (x) {
       if (x.type === md.Syntax.Html || x.type === md.Syntax.HtmlBlock) {
-        var htmlNode = getHtmlHeaders({children: [x]}, start, maxHeaderLevel, minHeaderLevel, false)[0];
+        var htmlNode = getHtmlHeaders({children: [x]}, start, maxHeaderLevel, 1, false)[0];
         return htmlNode ? {
           rank: htmlNode.rank,
           href: htmlNode.href,
@@ -107,7 +204,7 @@ function getMarkdownHeaders (lines, start, maxHeaderLevel, minHeaderLevel, synta
           node: x
         } : null;
       }
-      else if (x.type == md.Syntax.Header && x.depth >= minHeaderLevel && (!maxHeaderLevel || x.depth <= maxHeaderLevel)) {
+      else if (x.type == md.Syntax.Header && (!maxHeaderLevel || x.depth <= maxHeaderLevel)) {
         return { rank :  x.depth
           , name :  extractText(x)
           , line :  x.loc.start.line
@@ -196,9 +293,12 @@ function detectLineEnding(content, defaultEol) {
 
 exports = module.exports = function transform(content, mode, maxHeaderLevel, minHeaderLevel, minTocItems, title, notitle, entryPrefix, processAll, updateOnly, syntax, options) {
   options ??= {};
+  options.document ??= {};
+  options.document.lines ??= {};
   options.toc ??= {};
   options.toc.items ??= {};
   options.toc.items.indentation ??= {};
+  options.toc.pragma ??= {};
 
   syntax = syntax || "md";
   options.toc.items.indentation.style ??= 'space';
@@ -229,12 +329,6 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   var maxHeaderLevelHtml = maxHeaderLevel || 4;
 
   var docNodes = md.parse(content);
-  var tocs = getTocMarkers(docNodes, options?.toc?.pragma?.style, syntax, eol);
-
-  if (!(tocs.positions?.length > 0) && updateOnly) {
-    return { transformed: false };
-  }
-
   var startLine = 0;
   var startPos = 0;
   var firstChild = docNodes.children.length > 0 ? docNodes.children[0] : undefined;
@@ -263,49 +357,43 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
     startPos = startPos + eol.length;
   }
 
-  if (!(tocs.positions?.length > 0)) {
-    var insertPos = startPos;
-    tocs.positions = [{
-      end: {
-        range: [insertPos, insertPos],
-        raw: tocs.marker.end,
-      },
-      start: {
-        range: [insertPos, insertPos],
-        raw: tocs.marker.start,
-      },
-      existing: false
-    }];
+  var headers = getMarkdownHeaders(docNodes, startPos, maxHeaderLevel, syntax)
+    .concat(getHtmlHeaders(docNodes, startPos, maxHeaderLevelHtml, minHeaderLevel, true));
+  var minLines = options.document.lines.min + startLine || startLine;
+  var tooShort = headers.length < minTocItems || docNodes.children[docNodes.children.length - 1].loc.end.line < minLines;
+
+  headers = headers.filter(function (x) {
+      return x.name && x.name?.length > 0;
+    });
+  if (!tooShort) {
+    headers = processHeaders(headers, mode);
   }
+  
+  var sections = getSections(docNodes, headers, options, syntax, eol, processAll, startPos, minHeaderLevel);
 
-  var tocPosition = tocs.positions[0];
-  var tocableStart = !processAll ? tocPosition.end.range[1] : startPos;
-  var headers = getMarkdownHeaders(docNodes, tocableStart, maxHeaderLevel, minHeaderLevel, syntax)
-    .concat(getHtmlHeaders(docNodes, tocableStart, maxHeaderLevelHtml, minHeaderLevel, true));
+  if (sections.length > 1){
+    log.warn('Document contains ' + sections.length + ' sections. It can only contain 1.')
+    return { transformed: false };
+  }
+  var tocPosition = sections[0];
 
-  var initialNode = headers[0]?.node;
-  if (!tocPosition.existing && options?.toc?.location?.toLowerCase() == 'before' && initialNode) {
-    var insertPos = initialNode.range[0];
-    tocPosition.start.range = [insertPos, insertPos];
-    tocPosition.end.range = [insertPos, insertPos];
+  if (!tocPosition.existing && updateOnly) {
+    return { transformed: false };
   }
 
   var toc = '';
   var wrappedToc;
-  var minLines = options?.document?.lines?.min + startLine || startLine;
+  
   if (tocPosition.existing) {
     minLines = minLines + tocPosition.end.loc.end.line - tocPosition.start.loc.start.line + 2;
   }
-  
-  headers = headers.filter(function (x) {
-      return x.name && x.name?.length > 0;
-    });
+  tooShort = tooShort || docNodes.children[docNodes.children.length - 1].loc.end.line < minLines;
 
-  if (headers.length >= minTocItems && docNodes.children[docNodes.children.length - 1].loc.end.line >= minLines) {
+  if (!tooShort){
     var tocLines = [];
     var inferredTitle = determineTitle(docNodes, tocPosition, title, notitle, options?.toc?.header?.content);
     
-    var allHeaders = processHeaders(headers, mode);
+    var allHeaders = tocPosition.headings;
     var lowestRank = allHeaders.reduce((min, h) => Math.min(min, h.rank), Infinity);
     
     var indentation = options.toc.items.indentation.style === 'tab' ? '\t' : ' ';

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -118,7 +118,7 @@ function getSections(docNodes, headers, options, syntax, eol, processAll, insert
         range: [insertPos, insertPos],
         raw: markers.marker.start,
       },
-      headings: [headers[i]],
+      headings: [],
       existing: false
     });
   }
@@ -426,7 +426,7 @@ exports = module.exports = function transform(content, mode, maxHeaderLevel, min
   if (tocPosition.existing) {
     minLines = minLines + tocPosition.end.loc.end.line - tocPosition.start.loc.start.line + 2;
   }
-  tooShort = tooShort || docNodes.children[docNodes.children.length - 1].loc.end.line < minLines;
+  tooShort = tooShort || tocPosition.headings.length < minTocItems || docNodes.children[docNodes.children.length - 1].loc.end.line < minLines;
 
   if (!tooShort){
     var tocLines = [];

--- a/test/fixtures/readme-with-sections.md
+++ b/test/fixtures/readme-with-sections.md
@@ -1,0 +1,19 @@
+---
+title: Yaml Front Matter
+---
+
+# API 1
+
+Your regular Markdown content follows...
+
+## Heading 1
+## Sub-Heading 1
+Content
+
+# API 2
+
+Your regular Markdown content follows...
+
+## Heading 2
+## Sub-Heading 2
+Content

--- a/test/transform-stdout.js
+++ b/test/transform-stdout.js
@@ -75,3 +75,12 @@ test('\nshould exit with error code as --stdout option is not supported on multi
       }
     })
  })
+
+test('\nshould print file not processed due to multiple sections', function (t) {
+
+  exec('node doctoc.js test/fixtures/readme-with-sections.md --minlevel 2', function (error, stdout, stderr) {
+    t.same(stderr, 'Document contains 2 sections. It can only contain 1.\n', 'spits out the correct error message')
+
+    t.end()
+  })
+})

--- a/test/transform.js
+++ b/test/transform.js
@@ -425,6 +425,21 @@ check(
     , '## H2h'
     , '### H3h'
     , ''
+    , 'Min. level test'
+    ].join('\n')
+  , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'
+    , '- [H3h](#h3h)\n\n\n'
+    ].join('')
+  , undefined
+  , undefined
+  , 3
+)
+
+check(
+    [ '# H1h'
+    , '## H2h'
+    , '### H3h'
+    , ''
     , 'Same Max. & Min. level (not 1) test - hashed'
     ].join('\n')
   , [ '**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*\n\n'


### PR DESCRIPTION
Closes: #140
Progresses: #78

This has the toc headers  grouped into sections with the sections formed based on min level. In the case where multiple sections are found it exits, with stderr.

By grouping the headers into sections we can easily support sections in v3 and it provides an out of the box solution for handling the edge case of having multiple headers below the min level.   

It is easier to review with whitespace off aka https://github.com/thlorenz/doctoc/pull/368/changes?w=1